### PR TITLE
feat: integration tests for ZK scaling

### DIFF
--- a/lib/charms/kafka/v0/kafka_snap.py
+++ b/lib/charms/kafka/v0/kafka_snap.py
@@ -185,7 +185,7 @@ class KafkaSnap:
 
     @staticmethod
     def set_auth_config(sync_password: str, super_password: str) -> None:
-        """Generate content of the auth ZooKeeper config file"""
+        """Sets the content of the auth ZooKeeper JAAS file with passwords on the unit."""
         auth_config = f"""
             QuorumServer {{
                 org.apache.zookeeper.server.auth.DigestLoginModule required
@@ -205,6 +205,7 @@ class KafkaSnap:
         safe_write_to_file(content=str(auth_config), path=f"{AUTH_CONFIG_PATH}", mode="w")
 
     def set_kafka_opts(self) -> None:
+        """Sets the env-vars needed for SASL auth to /etc/environment on the unit."""
         opt_properties = " ".join(
             [
                 "-Dzookeeper.requireClientAuthScheme=sasl",

--- a/lib/charms/kafka/v0/kafka_snap.py
+++ b/lib/charms/kafka/v0/kafka_snap.py
@@ -202,7 +202,6 @@ class KafkaSnap:
                 user_super="{super_password}";
             }};
         """
-        logger.info(f"{auth_config=}")
         safe_write_to_file(content=str(auth_config), path=f"{AUTH_CONFIG_PATH}", mode="w")
 
     def set_kafka_opts(self) -> None:

--- a/lib/charms/zookeeper/v0/cluster.py
+++ b/lib/charms/zookeeper/v0/cluster.py
@@ -137,7 +137,7 @@ class ZooKeeperCluster:
 
     @staticmethod
     def get_unit_id(unit: Unit) -> int:
-        """Grabs the unit's ID as definied by Juju.
+        """Grabs the unit's ID as defined by Juju.
 
         Args:
             unit: The target `Unit`
@@ -236,7 +236,7 @@ class ZooKeeperCluster:
         return updated_servers
 
     def update_cluster(self) -> Dict[str, str]:
-        """Adds and removes members from the current ZK quroum.
+        """Adds and removes members from the current ZK quorum.
 
         To be ran by the Juju leader.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -121,6 +121,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tenacity"
+version = "8.0.1"
+description = "Retry code until it succeeds"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -139,7 +150,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8"
-content-hash = "5516712bf1f5c0c4d1f87b8b9e845b76ac49fd628244e3631ff26979f949e66d"
+content-hash = "d82eed55b7f4b2a3a34485c82ca0e9795b25a08518cd3b1477e917349370aee4"
 
 [metadata.files]
 black = [
@@ -237,6 +248,10 @@ pyyaml = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+tenacity = [
+    {file = "tenacity-8.0.1-py3-none-any.whl", hash = "sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a"},
+    {file = "tenacity-8.0.1.tar.gz", hash = "sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,12 @@ authors = [""]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-
-# Linting tools configuration
 black = "^22.3.0"
 kazoo = "^2.8.0"
 ops = "1.5.0"
 pure-sasl = "^0.6.2"
+tenacity = "^8.0.1"
+
 [tool.flake8]
 max-line-length = 99
 max-doc-length = 99

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ops >= 1.5.0
 kazoo >= 2.8.0
 pure-sasl >= 0.6.2
+tenacity >= 8.0.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -130,9 +130,6 @@ class ZooKeeperCharm(CharmBase):
         if not self.unit.is_leader():
             return
 
-        if getattr(event, "departing_unit", None) == self.unit:
-            return
-
         # units need to exist in the app data to be iterated through for next_turn
         for unit in self.cluster.started_units:
             unit_id = self.cluster.get_unit_id(unit)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/integration/scaling_helpers.py
+++ b/tests/integration/scaling_helpers.py
@@ -82,6 +82,11 @@ def check_key(host: str, password: str, username: str = "super") -> None:
 
 
 def srvr(host: str) -> Dict:
+    """Retrieves attributes returned from the 'srvr' 4lw command.
+
+    Specifically for this test, we are interested in the "Mode" of the ZK server,
+    which allows checking quorum leadership and follower active status.
+    """
     response = check_output(
         f"echo srvr | nc {host} 2181", stderr=PIPE, shell=True, universal_newlines=True
     )

--- a/tests/integration/scaling_helpers.py
+++ b/tests/integration/scaling_helpers.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import re
+from pathlib import Path
+from subprocess import PIPE, check_output
+from typing import Dict
+
+import yaml
+from kazoo.client import KazooClient
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+
+
+def get_password(model_full_name: str) -> str:
+    # getting relation data
+    show_unit = check_output(
+        f"JUJU_MODEL={model_full_name} juju show-unit {APP_NAME}/0",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+    response = yaml.safe_load(show_unit)
+    password = response[f"{APP_NAME}/0"]["relation-info"][0]["application-data"]["super_password"]
+    return password
+
+
+def restart_unit(model_full_name: str, unit: str) -> None:
+    # getting juju id
+    machine_id = check_output(
+        f"JUJU_MODEL={model_full_name} juju status | grep {unit} | awk '{{ print $4 }}'",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+    # getting lxc machine name
+    machine_name = check_output(
+        f"JUJU_MODEL={model_full_name} juju machines | grep awk '{{print $4}}' | grep -e '-{machine_id}'| head -1",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+    _ = check_output(
+        f"lxc restart {machine_name}",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+
+def write_key(host: str, password: str, username: str = "super") -> None:
+    kc = KazooClient(
+        hosts=host,
+        sasl_options={"mechanism": "DIGEST-MD5", "username": username, "password": password},
+    )
+    kc.start()
+    kc.create_async("/legolas", b"hobbits")
+    kc.stop()
+    kc.close()
+
+
+def check_key(host: str, password: str, username: str = "super") -> None:
+    kc = KazooClient(
+        hosts=host,
+        sasl_options={"mechanism": "DIGEST-MD5", "username": username, "password": password},
+    )
+    kc.start()
+    assert kc.exists_async("/legolas")
+    value, _ = kc.get_async("/legolas") or None, None
+
+    stored_value = ""
+    if value:
+        stored_value = value.get()
+    if stored_value:
+        assert stored_value[0] == b"hobbits"
+        return
+
+    raise KeyError
+
+
+def srvr(host: str) -> Dict:
+    response = check_output(
+        f"echo srvr | nc {host} 2181", stderr=PIPE, shell=True, universal_newlines=True
+    )
+
+    result = {}
+    for item in response.splitlines():
+        k = re.split(": ", item)[0]
+        v = re.split(": ", item)[1]
+        result[k] = v
+
+    return result

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,9 +5,14 @@
 import logging
 from pathlib import Path
 
+import re
+import time
+from kazoo.client import KazooClient
+from typing import Dict
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
+from subprocess import PIPE, check_output
 
 logger = logging.getLogger(__name__)
 
@@ -15,11 +20,169 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
-@pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest):
-    charm = await ops_test.build_charm(".")
+def get_password(model_full_name):
+    show_unit = check_output(
+        f"JUJU_MODEL={model_full_name} juju show-unit {APP_NAME}/0",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+    response = yaml.safe_load(show_unit)
+    password = response[f"{APP_NAME}/0"]["relation-info"][0]["application-data"]["super_password"]
+    logger.info(f"{password=}")
+    return password
 
-    await ops_test.model.deploy(charm, application_name=APP_NAME)
+
+def restart_unit(model_full_name: str, unit: str):
+    check_output(
+        f"JUJU_MODEL={model_full_name} juju ssh {unit} -i sudo snap stop kafka.zookeeper",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+    time.sleep(10)
+    check_output(
+        f"JUJU_MODEL={model_full_name} juju ssh {unit} -i sudo snap start kafka.zookeeper",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+
+def write_key(host: str, password: str, username: str = "super"):
+    kc = KazooClient(
+        hosts=host,
+        sasl_options={"mechanism": "DIGEST-MD5", "username": username, "password": password},
+    )
+    kc.start()
+    kc.create_async("/legolas", b"hobbits")
+    kc.stop()
+    kc.close()
+
+
+def check_key(host: str, password: str, username: str = "super"):
+    kc = KazooClient(
+        hosts=host,
+        sasl_options={"mechanism": "DIGEST-MD5", "username": username, "password": password},
+    )
+    kc.start()
+    assert kc.exists_async("/legolas")
+    value, _ = kc.get_async("/legolas") or None, None
+    assert value.get()[0] == b"hobbits"
+    kc.stop()
+    kc.close()
+
+
+def srvr(host: str) -> Dict:
+    response = check_output(
+        f"echo srvr | nc {host} 2181", stderr=PIPE, shell=True, universal_newlines=True
+    )
+
+    result = {}
+    for item in response.splitlines():
+        k = re.split(": ", item)[0]
+        v = re.split(": ", item)[1]
+        result[k] = v
+
+    return result
+
+
+async def ping_servers(ops_test: OpsTest):
+    logger.info("pinging servers")
+    for unit in ops_test.model.applications[APP_NAME].units:
+        host = unit.public_address
+        logger.info(f"{srvr(host)=}")
+        mode = srvr(host)["Mode"]
+        assert mode in ["leader", "follower"]
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_active(ops_test: OpsTest):
+    charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+    for unit in range(3):
+        assert ops_test.model.applications[APP_NAME].units[unit].workload_status == "active"
+    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+
+
+@pytest.mark.abort_on_fail
+async def test_simple_scale_up(ops_test: OpsTest):
+    await ops_test.model.applications[APP_NAME].add_units(count=3)
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 6)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    await ping_servers(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_simple_scale_down(ops_test: OpsTest):
+    await ops_test.model.applications[APP_NAME].destroy_units(
+        f"{APP_NAME}/5", f"{APP_NAME}/4", f"{APP_NAME}/3"
+    )
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    await ping_servers(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_scale_up_replication(ops_test: OpsTest):
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    await ping_servers(ops_test)
+    host = ops_test.model.applications[APP_NAME].units[0].public_address
+    model_full_name = ops_test.model_full_name
+    password = get_password(model_full_name)
+    write_key(host=host, password=password)
+    await ops_test.model.applications[APP_NAME].add_units(count=1)
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 4)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    check_key(host=host, password=password)
+
+
+@pytest.mark.abort_on_fail
+async def test_kill_quorum_leader_remove(ops_test: OpsTest):
+    await ops_test.model.applications[APP_NAME].destroy_units(f"{APP_NAME}/0")
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    await ping_servers(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_kill_juju_leader_remove(ops_test: OpsTest):
+    leader = None
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if await unit.is_leader_from_status():
+            leader = unit.name
+            break
+
+    if leader:
+        await ops_test.model.applications[APP_NAME].destroy_units(leader)
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[APP_NAME].units) == 2
+        )
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+        await ping_servers(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_kill_juju_leader_restart(ops_test: OpsTest):
+    leader = None
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if await unit.is_leader_from_status():
+            leader = unit.name
+            break
+
+    if leader:
+        await ops_test.model.applications[APP_NAME].add_units(count=1)
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[APP_NAME].units) == 3
+        )
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+
+        model_full_name = ops_test.model_full_name
+        if model_full_name:
+            restart_unit(model_full_name=model_full_name, unit=leader)
+            await ping_servers(ops_test)
+        else:
+            raise

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
-from scaling_helpers import check_key, get_password, restart_unit, srvr, write_key
+from tests.integration.scaling_helpers import check_key, get_password, restart_unit, srvr, write_key
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -9,7 +9,14 @@ from pathlib import Path
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
-from tests.integration.scaling_helpers import check_key, get_password, restart_unit, srvr, write_key
+
+from tests.integration.scaling_helpers import (
+    check_key,
+    get_password,
+    restart_unit,
+    srvr,
+    write_key,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -120,15 +120,13 @@ class TestManager(unittest.TestCase):
     @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
     @patch.object(DummyClient, "reconfig")
     def test_add_members_runs_on_leader(self, _, client):
-        zk = ZooKeeperManager(
-            hosts=["server.1=bilbo.baggins"], tries=1, retry_delay=0.1, username="", password=""
-        )
+        zk = ZooKeeperManager(hosts=["server.1=bilbo.baggins"], username="", password="")
         zk.leader = "leader"
         zk.add_members(["server.2=sam.gamgee"])
 
         client.assert_called_with(
             hosts="leader:2181",
-            timeout=5.0,
+            timeout=1.0,
             sasl_options={"mechanism": "DIGEST-MD5", "username": "", "password": ""},
         )
 
@@ -157,6 +155,6 @@ class TestManager(unittest.TestCase):
 
         client.assert_called_with(
             hosts="leader:2181",
-            timeout=5.0,
+            timeout=1.0,
             sasl_options={"mechanism": "DIGEST-MD5", "username": "", "password": ""},
         )

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,8 @@ passenv =
 [testenv:refresh]
 description = Short refresh script for charm-dev
 commands = 
-    /bin/bash -ec "juju destroy-model kafka --force --destroy-storage --no-wait"
-    /bin/bash -ec "juju add-model kafka"
+    /bin/bash -ec "juju destroy-model zookeeper --force --destroy-storage --no-wait"
+    /bin/bash -ec "juju add-model zookeeper"
     /bin/bash -ec "charmcraft pack"
     /bin/bash -ec "juju deploy ./*.charm -n 3"
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = lint, unit
 application = zookeeper
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-lib_path = {toxinidir}/lib/charms/operator_libs_linux
+lib_path = {toxinidir}/lib/charms/zookeeper
 all_path = {[vars]src_path} {[vars]tst_path} 
 
 [testenv]
@@ -55,7 +55,7 @@ deps =
     codespell
 commands =
     # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
+    codespell {[vars]lib_path}
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
@@ -70,6 +70,7 @@ deps =
     pytest
     kazoo
     pure-sasl
+    tenacity
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
@@ -84,6 +85,7 @@ deps =
     juju
     kazoo
     pure-sasl
+    tenacity
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,9 @@ description = Run integration tests
 deps =
     pytest
     juju
+    kazoo
+    pure-sasl
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -vv --no-header --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Changes Made
- `fix: resolve issue with new quorum not being met fast enough` - Solved by adding a `retry` to leader finding, and by continuing loops over expected members in case of a connection `KazooTimeoutError`
    - If quorum leader went down, the Juju leader would be unable to find the new quorum leader because they hadn't yet been elected. We don't want to just `event.defer()`, as it would wait for the next `update-status` event before running, causing downtime
    - A small retry helps this without adding too much latency
    - Reloading `zk.server_members` from a property ensures that new member changes are found
- `fix: resolve issue where units ran out of defer events during start-up and getting stuck`
    - While waiting for the Juju leader to add lower-id units, ready-to-start units would run out of defer events and hang
    - Adding a small `sleep` before deferring helps this
- `docs: general docstrings and comments`
- `tests: integration tests for ZK scaling`. Covers the following cases:
    - Charm build + 3 unit deploy
    - Scale Up
    - Scale Down (and loss of quorum)
    - Data replication for new units
    - Quorum Leader failover
    - Juju Leader failover
    - Juju Leader restart 