### PR TITLE
feat: add provider relation auth data management for clients 

### DIFF
--- a/lib/charms/kafka/v0/kafka_snap.py
+++ b/lib/charms/kafka/v0/kafka_snap.py
@@ -115,6 +115,27 @@ class KafkaSnap:
             logger.error(str(e))
             return False
 
+    def restart_snap_service(self, snap_service: str) -> bool:
+        """Restarts snap service process.
+
+        If fails with expected errors, it will block the KafkaSnap instance from executing
+        additional non-idempotent methods.
+
+        Args:
+            snap_service: The desired service to run on the unit
+                `kafka` or `zookeeper`
+
+        Returns:
+            True if service successfully restarts. False otherwise.
+        """
+        try:
+            self.kafka.restart(services=[snap_service])
+            return True
+            # TODO: check if the service is actually running (i.e not failed silently)
+        except snap.SnapError as e:
+            logger.error(str(e))
+            return False
+
     def write_properties(self, properties: str, property_label: str) -> None:
         """Writes to the expected config file location for the Kafka Snap.
 
@@ -184,7 +205,7 @@ class KafkaSnap:
         return config_map
 
     @staticmethod
-    def set_zookeeper_auth_config(sync_password: str, super_password: str) -> None:
+    def set_zookeeper_auth_config(sync_password: str, super_password: str, users: str) -> None:
         """Sets the content of the auth ZooKeeper JAAS file with passwords on the unit."""
         auth_config = f"""
             QuorumServer {{

--- a/lib/charms/kafka/v0/kafka_snap.py
+++ b/lib/charms/kafka/v0/kafka_snap.py
@@ -184,7 +184,7 @@ class KafkaSnap:
         return config_map
 
     @staticmethod
-    def set_auth_config(sync_password: str, super_password: str) -> None:
+    def set_zookeeper_auth_config(sync_password: str, super_password: str) -> None:
         """Sets the content of the auth ZooKeeper JAAS file with passwords on the unit."""
         auth_config = f"""
             QuorumServer {{
@@ -204,7 +204,7 @@ class KafkaSnap:
         """
         safe_write_to_file(content=str(auth_config), path=f"{AUTH_CONFIG_PATH}", mode="w")
 
-    def set_kafka_opts(self) -> None:
+    def set_zookeeper_kafka_opts(self) -> None:
         """Sets the env-vars needed for SASL auth to /etc/environment on the unit."""
         opt_properties = " ".join(
             [

--- a/lib/charms/kafka/v0/kafka_snap.py
+++ b/lib/charms/kafka/v0/kafka_snap.py
@@ -206,20 +206,29 @@ class KafkaSnap:
 
     @staticmethod
     def set_zookeeper_auth_config(sync_password: str, super_password: str, users: str) -> None:
-        """Sets the content of the auth ZooKeeper JAAS file with passwords on the unit."""
+        """Sets the content of the auth ZooKeeper JAAS file with passwords on the unit.
+
+        Args:
+            sync_password: the ZK server-server auth password
+            super_password: the ZK super user password
+            users: the users to give access to
+                Format `user_username="password"\\n`
+        """
         auth_config = f"""
             QuorumServer {{
                 org.apache.zookeeper.server.auth.DigestLoginModule required
                 user_sync="{sync_password}";
             }};
+
             QuorumLearner {{
                 org.apache.zookeeper.server.auth.DigestLoginModule required
                 username="sync"
                 password="{sync_password}";
             }};
-            
+
             Server {{
                 org.apache.zookeeper.server.auth.DigestLoginModule required
+                {users}
                 user_super="{super_password}";
             }};
         """

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -1,0 +1,390 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This library enables "rolling" operations across units of a charmed Application.
+
+For example, a charm author might use this library to implement a "rolling restart", in
+which all units in an application restart their workload, but no two units execute the
+restart at the same time.
+
+To implement the rolling restart, a charm author would do the following:
+
+1. Add a peer relation called 'restart' to a charm's `metadata.yaml`:
+```yaml
+peers:
+    restart:
+        interface: rolling_op
+```
+
+Import this library into src/charm.py, and initialize a RollingOpsManager in the Charm's
+`__init__`. The Charm should also define a callback routine, which will be executed when
+a unit holds the distributed lock:
+
+src/charm.py
+```python
+# ...
+from charms.rolling_ops.v0.rollingops import RollingOpsManager
+# ...
+class SomeCharm(...):
+    def __init__(...)
+        # ...
+        self.restart_manager = RollingOpsManager(
+            charm=self, relation="restart", callback=self._restart
+        )
+        # ...
+    def _restart(self, event):
+        systemd.service_restart('foo')
+```
+
+To kick off the rolling restart, emit this library's AcquireLock event. The simplest way
+to do so would be with an action, though it might make sense to acquire the lock in
+response to another event. 
+
+```python
+    def _on_trigger_restart(self, event):
+        self.charm.on[self.restart_manager.name].acquire_lock.emit()
+```
+
+In order to trigger the restart, a human operator would execute the following command on
+the CLI:
+
+```
+juju run-action some-charm/0 some-charm/1 <... some-charm/n> restart
+```
+
+Note that all units that plan to restart must receive the action and emit the aquire
+event. Any units that do not run their acquire handler will be left out of the rolling
+restart. (An operator might take advantage of this fact to recover from a failed rolling
+operation without restarting workloads that were able to successfully restart -- simply
+omit the successful units from a subsequent run-action call.)
+
+"""
+import logging
+from enum import Enum
+from typing import AnyStr, Callable
+
+from ops.charm import ActionEvent, CharmBase, RelationChangedEvent
+from ops.framework import EventBase, Object
+from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "20b7777f58fe421e9a223aefc2b4d3a4"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+
+class LockNoRelationError(Exception):
+    """Raised if we are trying to process a lock, but do not appear to have a relation yet."""
+
+    pass
+
+
+class LockState(Enum):
+    """Possible states for our Distributed lock.
+
+    Note that there are two states set on the unit, and two on the application.
+
+    """
+
+    ACQUIRE = "acquire"
+    RELEASE = "release"
+    GRANTED = "granted"
+    IDLE = "idle"
+
+
+class Lock:
+    """A class that keeps track of a single asynchronous lock.
+
+    Warning: a Lock has permission to update relation data, which means that there are
+    side effects to invoking the .acquire, .release and .grant methods. Running any one of
+    them will trigger a RelationChanged event, once per transition from one internal
+    status to another.
+
+    This class tracks state across the cloud by implementing a peer relation
+    interface. There are two parts to the interface:
+
+    1) The data on a unit's peer relation (defined in metadata.yaml.) Each unit can update
+       this data. The only meaningful values are "acquire", and "release", which represent
+       a request to acquire the lock, and a request to release the lock, respectively.
+
+    2) The application data in the relation. This tracks whether the lock has been
+       "granted", Or has been released (and reverted to idle). There are two valid states:
+       "granted" or None.  If a lock is in the "granted" state, a unit should emit a
+       RunWithLocks event and then release the lock.
+
+       If a lock is in "None", this means that a unit has not yet requested the lock, or
+       that the request has been completed.
+
+    In more detail, here is the relation structure:
+
+    relation.data:
+        <unit n>:
+            status: 'acquire|release'
+        <application>:
+           <unit n>: 'granted|None'
+
+    Note that this class makes no attempts to timestamp the locks and thus handle multiple
+    requests in a row. If a unit re-requests a lock before being granted the lock, the
+    lock will simply stay in the "acquire" state. If a unit wishes to clear its lock, it
+    simply needs to call lock.release().
+
+    """
+
+    def __init__(self, manager, unit=None):
+
+        self.relation = manager.model.relations[manager.name][0]
+        if not self.relation:
+            # TODO: defer caller in this case (probably just fired too soon).
+            raise LockNoRelationError()
+
+        self.unit = unit or manager.model.unit
+        self.app = manager.model.app
+
+    @property
+    def _state(self) -> LockState:
+        """Return an appropriate state.
+
+        Note that the state exists in the unit's relation data, and the application
+        relation data, so we have to be careful about what our states mean.
+
+        Unit state can only be in "acquire", "release", "None" (None means unset)
+        Application state can only be in "granted" or "None" (None means unset or released)
+
+        """
+        unit_state = LockState(self.relation.data[self.unit].get("state", LockState.IDLE.value))
+        app_state = LockState(
+            self.relation.data[self.app].get(str(self.unit), LockState.IDLE.value)
+        )
+
+        if app_state == LockState.GRANTED and unit_state == LockState.RELEASE:
+            # Active release request.
+            return LockState.RELEASE
+
+        if app_state == LockState.IDLE and unit_state == LockState.ACQUIRE:
+            # Active acquire request.
+            return LockState.ACQUIRE
+
+        return app_state  # Granted or unset/released
+
+    @_state.setter
+    def _state(self, state: LockState):
+        """Set the given state.
+
+        Since we update the relation data, this may fire off a RelationChanged event.
+        """
+        if state == LockState.ACQUIRE:
+            self.relation.data[self.unit].update({"state": state.value})
+
+        if state == LockState.RELEASE:
+            self.relation.data[self.unit].update({"state": state.value})
+
+        if state == LockState.GRANTED:
+            self.relation.data[self.app].update({str(self.unit): state.value})
+
+        if state is LockState.IDLE:
+            self.relation.data[self.app].update({str(self.unit): state.value})
+
+    def acquire(self):
+        """Request that a lock be acquired."""
+        self._state = LockState.ACQUIRE
+
+    def release(self):
+        """Request that a lock be released."""
+        self._state = LockState.RELEASE
+
+    def clear(self):
+        """Unset a lock."""
+        self._state = LockState.IDLE
+
+    def grant(self):
+        """Grant a lock to a unit."""
+        self._state = LockState.GRANTED
+
+    def is_held(self):
+        """This unit holds the lock."""
+        return self._state == LockState.GRANTED
+
+    def release_requested(self):
+        """A unit has reported that they are finished with the lock."""
+        return self._state == LockState.RELEASE
+
+    def is_pending(self):
+        """Is this unit waiting for a lock?"""
+        return self._state == LockState.ACQUIRE
+
+
+class Locks:
+    """Generator that returns a list of locks."""
+
+    def __init__(self, manager):
+        self.manager = manager
+
+        # Gather all the units.
+        relation = manager.model.relations[manager.name][0]
+        units = [unit for unit in relation.units]
+
+        # Plus our unit ...
+        units.append(manager.model.unit)
+
+        self.units = units
+
+    def __iter__(self):
+        """Yields a lock for each unit we can find on the relation."""
+        for unit in self.units:
+            yield Lock(self.manager, unit=unit)
+
+
+class RunWithLock(EventBase):
+    """Event to signal that this unit should run the callback."""
+
+    pass
+
+
+class AcquireLock(EventBase):
+    """Signals that this unit wants to acquire a lock."""
+
+    pass
+
+
+class ProcessLocks(EventBase):
+    """Used to tell the leader to process all locks."""
+
+    pass
+
+
+class RollingOpsManager(Object):
+    """Emitters and handlers for rolling ops."""
+
+    def __init__(self, charm: CharmBase, relation: AnyStr, callback: Callable):
+        """Register our custom events.
+
+        params:
+            charm: the charm we are attaching this to.
+            relation: an identifier, by convention based on the name of the relation in the
+                metadata.yaml, which identifies this instance of RollingOperatorsFactory,
+                distinct from other instances that may be hanlding other events.
+            callback: a closure to run when we have a lock. (It must take a CharmBase object and
+                EventBase object as args.)
+        """
+        # "Inherit" from the charm's class. This gives us access to the framework as
+        # self.framework, as well as the self.model shortcut.
+        super().__init__(charm, None)
+
+        self.name = relation
+        self._callback = callback
+        self.charm = charm  # Maintain a reference to charm, so we can emit events.
+
+        charm.on.define_event("{}_run_with_lock".format(self.name), RunWithLock)
+        charm.on.define_event("{}_acquire_lock".format(self.name), AcquireLock)
+        charm.on.define_event("{}_process_locks".format(self.name), ProcessLocks)
+
+        # Watch those events (plus the built in relation event).
+        self.framework.observe(charm.on[self.name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on[self.name].acquire_lock, self._on_acquire_lock)
+        self.framework.observe(charm.on[self.name].run_with_lock, self._on_run_with_lock)
+        self.framework.observe(charm.on[self.name].process_locks, self._on_process_locks)
+
+    def _callback(self: CharmBase, event: EventBase) -> None:
+        """Placeholder for the function that actually runs our event.
+
+        Usually overridden in the init.
+        """
+        raise NotImplementedError
+
+    def _on_relation_changed(self: CharmBase, event: RelationChangedEvent):
+        """Process relation changed.
+
+        First, determine whether this unit has been granted a lock. If so, emit a RunWithLock
+        event.
+
+        Then, if we are the leader, fire off a process locks event.
+
+        """
+        lock = Lock(self)
+
+        if lock.is_pending():
+            self.model.unit.status = WaitingStatus("Awaiting {} operation".format(self.name))
+
+        if lock.is_held():
+            self.charm.on[self.name].run_with_lock.emit()
+
+        if self.model.unit.is_leader():
+            self.charm.on[self.name].process_locks.emit()
+
+    def _on_process_locks(self: CharmBase, event: ProcessLocks):
+        """Process locks.
+
+        Runs only on the leader. Updates the status of all locks.
+
+        """
+        if not self.model.unit.is_leader():
+            return
+
+        pending = []
+
+        for lock in Locks(self):
+            if lock.is_held():
+                # One of our units has the lock -- return without further processing.
+                return
+
+            if lock.release_requested():
+                lock.clear()  # Updates relation data
+
+            if lock.is_pending():
+                if lock.unit == self.model.unit:
+                    # Always run on the leader last.
+                    pending.insert(0, lock)
+                else:
+                    pending.append(lock)
+
+        # If we reach this point, and we have pending units, we want to grant a lock to
+        # one of them.
+        if pending:
+            self.model.app.status = MaintenanceStatus("Beginning rolling {}".format(self.name))
+            lock = pending[-1]
+            lock.grant()
+            if lock.unit == self.model.unit:
+                # It's time for the leader to run with lock.
+                self.charm.on[self.name].run_with_lock.emit()
+            return
+
+        self.model.app.status = ActiveStatus()
+
+    def _on_acquire_lock(self: CharmBase, event: ActionEvent):
+        """Request a lock."""
+        try:
+            Lock(self).acquire()  # Updates relation data
+            # emit relation changed event in the edge case where aquire does not
+            relation = self.model.get_relation(self.name)
+            self.charm.on[self.name].relation_changed.emit(relation)
+        except LockNoRelationError:
+            logger.debug("No {} peer relation yet. Delaying rolling op.".format(self.name))
+            event.defer()
+
+    def _on_run_with_lock(self: CharmBase, event: RunWithLock):
+        lock = Lock(self)
+        self.model.unit.status = MaintenanceStatus("Executing {} operation".format(self.name))
+        self._callback(event)
+        lock.release()  # Updates relation data
+        if lock.unit == self.model.unit:
+            self.charm.on[self.name].process_locks.emit()
+
+        self.model.unit.status = ActiveStatus()

--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -297,7 +297,7 @@ class ZooKeeperClient:
         if self.client.connected:
             return "broadcast" in self.mntr.get("zk_peer_state", "")
         return False
-    
+
     def get_all_znode_children(self, path: str) -> Set[str]:
         """Recursively gets all children for a given parent znode path.
 
@@ -322,7 +322,7 @@ class ZooKeeperClient:
         """Drop znode and all it's children from ZK tree.
 
         Args:
-            path: the desired znode path to delete 
+            path: the desired znode path to delete
         """
         if not self.client.exists(path):
             return
@@ -330,7 +330,7 @@ class ZooKeeperClient:
 
     def create_znode(self, path: str, acls: List[ACL]) -> None:
         """Create new znode.
-        
+
         Args:
             path: the desired znode path to create
             acls: the acls for the new znode
@@ -347,7 +347,7 @@ class ZooKeeperClient:
             List of the acls set for the given znode
         """
         acl_list = self.client.get_acls(path)
-        
+
         return acl_list if acl_list else []
 
     def set_acls(self, path: str, acls: List[ACL]) -> None:
@@ -359,8 +359,3 @@ class ZooKeeperClient:
         """
         # TODO: bug maybe
         self.client.set_acls(path, acls)
-
-
-
-
-

--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -1,5 +1,4 @@
 import logging
-from os import pathsep
 import re
 from typing import Any, Dict, Iterable, List, Set, Tuple
 from kazoo.client import KazooClient
@@ -209,6 +208,44 @@ class ZooKeeperManager:
                     from_config=self.config_version,
                 )
 
+    def leader_znodes(self, path: str) -> Set[str]:
+        with ZooKeeperClient(
+            host=self.leader,
+            client_port=self.client_port,
+            username=self.username,
+            password=self.password,
+        ) as zk:
+            all_znode_children = zk.get_all_znode_children(path=path)
+
+        return all_znode_children
+
+    def create_znode_leader(self, path: str, acls: List[ACL]) -> None:
+        with ZooKeeperClient(
+            host=self.leader,
+            client_port=self.client_port,
+            username=self.username,
+            password=self.password,
+        ) as zk:
+            zk.create_znode(path=path, acls=acls)
+
+    def set_acls_znode_leader(self, path: str, acls: List[ACL]) -> None:
+        with ZooKeeperClient(
+            host=self.leader,
+            client_port=self.client_port,
+            username=self.username,
+            password=self.password,
+        ) as zk:
+            zk.set_acls(path=path, acls=acls)
+
+    def delete_znode_leader(self, path: str) -> None:
+        with ZooKeeperClient(
+            host=self.leader,
+            client_port=self.client_port,
+            username=self.username,
+            password=self.password,
+        ) as zk:
+            zk.delete_znode(path=path)
+
 
 class ZooKeeperClient:
     """Handler for ZooKeeper connections and running 4lw client commands."""
@@ -357,5 +394,4 @@ class ZooKeeperClient:
             path: the desired znode path
             acls: the acls to set to the given znode
         """
-        # TODO: bug maybe
         self.client.set_acls(path, acls)

--- a/lib/charms/zookeeper/v0/cluster.py
+++ b/lib/charms/zookeeper/v0/cluster.py
@@ -6,7 +6,7 @@ import logging
 import secrets
 import string
 import re
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Set, Tuple, Union
 from kazoo.handlers.threading import KazooTimeoutError
 from ops.charm import CharmBase
 

--- a/lib/charms/zookeeper/v0/cluster.py
+++ b/lib/charms/zookeeper/v0/cluster.py
@@ -6,7 +6,7 @@ import logging
 import secrets
 import string
 import re
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 from kazoo.handlers.threading import KazooTimeoutError
 from ops.charm import CharmBase
 

--- a/lib/charms/zookeeper/v0/zookeeper_provider.py
+++ b/lib/charms/zookeeper/v0/zookeeper_provider.py
@@ -1,0 +1,190 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from collections import defaultdict
+import logging
+from typing import Dict, List, Optional, Set
+from kazoo.handlers.threading import KazooTimeoutError
+from kazoo.security import ACL, make_acl
+from ops.charm import RelationBrokenEvent, RelationEvent
+
+from ops.framework import Object
+from ops.model import MaintenanceStatus, Relation
+
+from charms.zookeeper.v0.client import MemberNotReadyError, MembersSyncingError, QuorumLeaderNotFoundError, ZooKeeperManager
+from charms.zookeeper.v0.cluster import UnitNotFoundError
+
+logger = logging.getLogger(__name__)
+
+REL_NAME = "database"
+PEER = "cluster"
+
+
+class ZooKeeperProvider(Object):
+    def __init__(self, charm) -> None:
+        super().__init__(charm, "client")
+
+        self.charm = charm
+
+        self.framework.observe(
+            self.charm.on[REL_NAME].relation_joined, self._on_client_relation_updated
+        )
+        self.framework.observe(
+            self.charm.on[REL_NAME].relation_changed, self._on_client_relation_updated
+        )
+        self.framework.observe(
+            self.charm.on[REL_NAME].relation_broken, self._on_client_relation_broken
+        )
+
+    @property
+    def app_relation(self):
+        """Gets the current ZK peer relation."""
+        return self.charm.model.get_relation(PEER)
+
+    @property
+    def client_relations(self):
+        """Gets the relations for all related client applications."""
+        return self.model.relations[REL_NAME]
+
+    def relation_config(self, relation: Relation, event: Optional[RelationEvent] = None) -> Optional[Dict[str, str]]:
+        """Gets the auth config for a currently related application."""
+
+        # If RelationBrokenEvent, skip, we don't want it in the live-data
+        if isinstance(event, RelationBrokenEvent):
+            return None
+        
+        # generating username
+        relation_id = relation.id
+        username = f"relation-{relation_id}"
+
+        # Default to empty string in case passwords not set
+        password = self.app_relation.data[self.charm.app].get(username, "")
+
+        # Default to full permissions if not set by the app
+        acl = relation.data[relation.app].get("chroot-acl", "cdrwa")
+
+        # Attempt to default to `database` app value. Else None, it's unset
+        chroot = relation.data[relation.app].get(
+            "chroot", relation.data[relation.app].get("database", "")
+        )
+
+        # If chroot is unset, skip, we don't want it part of the config
+        if not chroot:
+            logger.info("CHROOT NOT SET")
+            return None
+
+        if not str(chroot).startswith("/"):
+            chroot = f"/{chroot}"
+
+        return {"username": username, "password": password, "chroot": chroot, "acl": acl}
+
+    def relations_config(self, event: Optional[RelationEvent] = None) -> Dict[str, Dict[str, str]]:
+        """Gets auth configs for all currently related applications."""
+        relations_config = {}
+
+        for relation in self.client_relations:
+            config = self.relation_config(relation=relation, event=event)
+    
+            # in the case of RelationBroken or unset chroot
+            if not config:
+                continue
+
+            relation_id: int = relation.id
+            relations_config[str(relation_id)] = config
+
+        return relations_config
+
+    def build_acls(self) -> Dict[str, List[ACL]]:
+        """Gets ACLs for all currently related applications."""
+        acls = defaultdict(list)
+
+        for _, relation_config in self.relations_config.items():
+            chroot = relation_config["chroot"]
+            generated_acl = make_acl(
+                scheme="sasl",
+                credential=relation_config["username"],
+                read="r" in relation_config["acl"],
+                write="w" in relation_config["acl"],
+                create="c" in relation_config["acl"],
+                delete="d" in relation_config["acl"],
+                admin="a" in relation_config["acl"],
+            )
+
+            acls[chroot].append(generated_acl)
+
+        return acls
+
+    def relations_config_values_for_key(self, key: str, event: Optional[RelationEvent] = None) -> Set[str]:
+        """Grabs a specific auth config value from all related applications."""
+        return {config.get(key, "") for config in self.relations_config(event=event).values()}
+
+    def update_acls(self):
+        """Compares leader auth config to incoming relation config, applies necessary add/update/remove actions."""
+        super_password, _ = self.charm.cluster.passwords
+        zk = ZooKeeperManager(
+            hosts=self.charm.cluster.active_hosts, username="super", password=super_password
+        )
+
+        leader_chroots = zk.leader_znodes(path="/")
+        logger.info(f"{leader_chroots=}")
+
+        relation_chroots = self.relations_config_values_for_key("chroot")
+        logger.info(f"{relation_chroots=}")
+
+        acls = self.build_acls()
+        logger.info(f"{acls=}")
+
+        # Looks for newly related applications not in config yet 
+        for chroot in relation_chroots - leader_chroots:
+            logger.info(f"CREATE CHROOT - {chroot}")
+            zk.create_znode_leader(chroot, acls[chroot])
+
+        # Looks for existing related applications
+        for chroot in relation_chroots & leader_chroots:
+            logger.info(f"UPDATE CHROOT - {chroot}")
+            zk.set_acls_znode_leader(chroot, acls[chroot])
+
+        # Looks for applications no longer in the relation but still in config
+        for chroot in leader_chroots - relation_chroots:
+            # TODO: is_child_of
+            logger.info(f"DROP CHROOT - {chroot}")
+            zk.delete_znode_leader(chroot)
+
+    def _on_client_relation_updated(self, event: RelationEvent) -> None:
+        if not self.charm.unit.is_leader():
+            return
+        
+        try:
+            self.update_acls()
+        except (
+            MembersSyncingError,
+            MemberNotReadyError,
+            QuorumLeaderNotFoundError,
+            KazooTimeoutError,
+            UnitNotFoundError,
+        ) as e:
+            logger.warning(str(e))
+            self.charm.unit.status = MaintenanceStatus(str(e))
+            return
+
+        for relation_id, config in self.relations_config(event=event).items():
+            self.client_relations.data[REL_NAME, relation_id].update(config)
+            # TODO: generate password
+            # TODO: add uris, endpoints
+            # TODO: confirm passwords setting
+
+    def _on_client_relation_broken(self, event: RelationBrokenEvent):
+        if not self.charm.unit.is_leader():
+            return
+
+        # TODO: maybe remove departing app from event relation data?
+
+        config = self.relation_config(relation=event.relation)
+        username = config["username"] if config else ""
+
+        if username in self.charm.cluster.relation.data[self.charm.app]:
+            logger.info(f"DELETING - {username}")
+            del self.charm.cluster.relation.data[self.charm.app][username]
+        
+        # call normal updated handler
+        self._on_client_relation_updated(event=event)

--- a/lib/charms/zookeeper/v0/zookeeper_provider.py
+++ b/lib/charms/zookeeper/v0/zookeeper_provider.py
@@ -32,9 +32,6 @@ class ZooKeeperProvider(Object):
         self.charm = charm
 
         self.framework.observe(
-            self.charm.on[REL_NAME].relation_joined, self._on_client_relation_updated
-        )
-        self.framework.observe(
             self.charm.on[REL_NAME].relation_changed, self._on_client_relation_updated
         )
         self.framework.observe(
@@ -121,8 +118,7 @@ class ZooKeeperProvider(Object):
             if not config:
                 continue
 
-            relation_id: int = relation.id
-            relations_config[str(relation_id)] = config
+            relations_config[str(relation.id)] = config
 
         return relations_config
 
@@ -220,7 +216,7 @@ class ZooKeeperProvider(Object):
         return False
 
     def _on_client_relation_updated(self, event: RelationEvent) -> None:
-        """Updates ACLs while handling `client_relation_changed` and `client_relation_joined` events.
+        """Updates ACLs while handling `client_relation_changed`.
 
         Args:
             event (optional): used for checking `RelationBrokenEvent`
@@ -259,7 +255,7 @@ class ZooKeeperProvider(Object):
                 [f"{host}:{self.charm.cluster.client_port}{config['chroot']}" for host in hosts]
             )
 
-            self.app_relation.data[self.charm.app].update({config["username"]: config["password"]})
+            self.app_relation.data[self.charm.app].update({relation_data["username"]: relation_data["password"]})
 
             self.charm.model.get_relation(REL_NAME, int(relation_id)).data[self.charm.app].update(
                 relation_data

--- a/lib/charms/zookeeper/v0/zookeeper_provider.py
+++ b/lib/charms/zookeeper/v0/zookeeper_provider.py
@@ -62,7 +62,7 @@ class ZooKeeperProvider(Object):
                 If passed and is `RelationBrokenEvent`, will skip and return `None`
 
         Returns:
-            Dict containing relation `username`, `password`, `chroot` and `acl`
+            Dict containing relation `username`, `password`, `chroot`, `acl` and `jaas_user`
 
             `None` if `RelationBrokenEvent` is passed as event
         """
@@ -94,7 +94,13 @@ class ZooKeeperProvider(Object):
         if not str(chroot).startswith("/"):
             chroot = f"/{chroot}"
 
-        return {"username": username, "password": password, "chroot": chroot, "acl": acl}
+        return {
+            "username": username,
+            "password": password,
+            "chroot": chroot,
+            "acl": acl,
+            "jaas_user": f'user_{username}="{password}"',
+        }
 
     def relations_config(self, event: Optional[RelationEvent] = None) -> Dict[str, Dict[str, str]]:
         """Gets auth configs for all currently related applications.
@@ -212,24 +218,6 @@ class ZooKeeperProvider(Object):
                 return True
 
         return False
-
-    @staticmethod
-    def build_uris(active_hosts: Set[str], chroot: str, client_port: int = 2181) -> List[str]:
-        """Builds connection uris for passing to the client relation data.
-
-        Args:
-            active_hosts: all ZK hosts in the peer relation
-            chroot: the chroot to append to the host IP
-            client_port: the client_port to append to the host IP
-
-        Returns:
-            List of chroot appended connection uris
-        """
-        uris = []
-        for host in active_hosts:
-            uris.append(f"{host}:{client_port}{chroot}")
-
-        return uris
 
     def _on_client_relation_updated(self, event: RelationEvent) -> None:
         """Updates ACLs while handling `client_relation_changed` and `client_relation_joined` events.

--- a/lib/charms/zookeeper/v0/zookeeper_provider.py
+++ b/lib/charms/zookeeper/v0/zookeeper_provider.py
@@ -120,7 +120,7 @@ class ZooKeeperProvider(Object):
 
         return relations_config
 
-    def build_acls(self, event: Optional[RelationEvent]) -> Dict[str, List[ACL]]:
+    def build_acls(self, event: Optional[RelationEvent] = None) -> Dict[str, List[ACL]]:
         """Gets ACLs for all currently related applications.
 
         Args:
@@ -160,7 +160,7 @@ class ZooKeeperProvider(Object):
         """
         return {config.get(key, "") for config in self.relations_config(event=event).values()}
 
-    def update_acls(self, event: Optional[RelationEvent]) -> None:
+    def update_acls(self, event: Optional[RelationEvent] = None) -> None:
         """Compares leader auth config to incoming relation config, applies necessary add/update/remove actions.
 
         Args:

--- a/lib/charms/zookeeper/v0/zookeeper_provider.py
+++ b/lib/charms/zookeeper/v0/zookeeper_provider.py
@@ -21,7 +21,7 @@ from charms.zookeeper.v0.cluster import UnitNotFoundError, ZooKeeperCluster
 
 logger = logging.getLogger(__name__)
 
-REL_NAME = "database"
+REL_NAME = "zookeeper"
 PEER = "cluster"
 
 
@@ -255,7 +255,9 @@ class ZooKeeperProvider(Object):
                 [f"{host}:{self.charm.cluster.client_port}{config['chroot']}" for host in hosts]
             )
 
-            self.app_relation.data[self.charm.app].update({relation_data["username"]: relation_data["password"]})
+            self.app_relation.data[self.charm.app].update(
+                {relation_data["username"]: relation_data["password"]}
+            )
 
             self.charm.model.get_relation(REL_NAME, int(relation_id)).data[self.charm.app].update(
                 relation_data

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ peers:
   cluster:
     interface: cluster
   restart:
-    rolling_ops
+    rolling_op
 
 provides:
   zookeeper:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ peers:
   cluster:
     interface: cluster
   restart:
-    rolling_op
+    rolling_ops
 
 provides:
   zookeeper:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,9 +14,10 @@ peers:
   cluster:
     interface: cluster
   restart:
-    rolling_op
+    interface:
+      rolling_op
 
 provides:
-  zookeeper:
+  database:
     interface: zookeeper
     limit: 1 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,6 +13,8 @@ maintainers:
 peers:
   cluster:
     interface: cluster
+  restart:
+    rolling_op
 
 provides:
   zookeeper:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,10 +14,9 @@ peers:
   cluster:
     interface: cluster
   restart:
-    interface:
-      rolling_op
+    interface: rolling_op
 
 provides:
-  database:
+  zookeeper:
     interface: zookeeper
     limit: 1 

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,12 +15,11 @@ from charms.zookeeper.v0.cluster import (
     UnitNotFoundError,
     ZooKeeperCluster,
 )
+from charms.zookeeper.v0.zookeeper_provider import ZooKeeperProvider
 from ops.charm import CharmBase
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
-
-from charms.zookeeper.v0.zookeeper_provider import ZooKeeperProvider
 
 logger = logging.getLogger(__name__)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,8 @@ from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 
+from charms.zookeeper.v0.zookeeper_provider import ZooKeeperProvider
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,6 +38,7 @@ class ZooKeeperCharm(CharmBase):
         self.snap = KafkaSnap()
         self.cluster = ZooKeeperCluster(self)
         self.restart = RollingOpsManager(self, relation="restart", callback=lambda x: x)
+        self.client_relation = ZooKeeperProvider(self)
 
         self.framework.observe(getattr(self.on, "install"), self._on_install)
         self.framework.observe(getattr(self.on, "start"), self._on_start)

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,7 @@ import logging
 import time
 
 from charms.kafka.v0.kafka_snap import KafkaSnap
+from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from charms.zookeeper.v0.cluster import (
     NoPasswordError,
     NotUnitTurnError,
@@ -18,7 +19,6 @@ from ops.charm import CharmBase
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
-from charms.rolling_ops.v0.rollingops import RollingOpsManager
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,9 @@ class ZooKeeperCharm(CharmBase):
 
         # KAFKA_OPTS env var gets loaded on snap start
         super_password, sync_password = self.cluster.passwords
-        self.snap.set_zookeeper_auth_config(sync_password=sync_password, super_password=super_password)
+        self.snap.set_zookeeper_auth_config(
+            sync_password=sync_password, super_password=super_password
+        )
         self.snap.set_zookeeper_kafka_opts()
 
         self.snap.start_snap_service(snap_service=CHARM_KEY)

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,6 +35,7 @@ class ZooKeeperCharm(CharmBase):
         self.name = CHARM_KEY
         self.snap = KafkaSnap()
         self.cluster = ZooKeeperCluster(self)
+        self.restart = RollingOpsManager(self, relation="restart", callback=lambda x: x)
 
         self.framework.observe(getattr(self.on, "install"), self._on_install)
         self.framework.observe(getattr(self.on, "start"), self._on_start)
@@ -110,8 +111,8 @@ class ZooKeeperCharm(CharmBase):
 
         # KAFKA_OPTS env var gets loaded on snap start
         super_password, sync_password = self.cluster.passwords
-        self.snap.set_auth_config(sync_password=sync_password, super_password=super_password)
-        self.snap.set_kafka_opts()
+        self.snap.set_zookeeper_auth_config(sync_password=sync_password, super_password=super_password)
+        self.snap.set_zookeeper_kafka_opts()
 
         self.snap.start_snap_service(snap_service=CHARM_KEY)
         self.unit.status = ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,6 +18,7 @@ from ops.charm import CharmBase
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from charms.rolling_ops.v0.rollingops import RollingOpsManager
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_zookeeper_provider.py
+++ b/tests/unit/test_zookeeper_provider.py
@@ -2,15 +2,15 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 import re
 import unittest
-from ops.charm import CharmBase, RelationBrokenEvent
-from charms.zookeeper.v0.cluster import ZooKeeperCluster
-from charms.zookeeper.v0.zookeeper_provider import ZooKeeperProvider
-from ops.testing import Harness
-import logging
 
 import ops.testing
+from charms.zookeeper.v0.cluster import ZooKeeperCluster
+from charms.zookeeper.v0.zookeeper_provider import ZooKeeperProvider
+from ops.charm import CharmBase, RelationBrokenEvent
+from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 
@@ -234,7 +234,7 @@ class TestCluster(unittest.TestCase):
         usernames = []
         for relation in self.provider.client_relations:
 
-            # checking existance of all necessary keys
+            # checking existence of all necessary keys
             self.assertEqual(
                 sorted(relation.data[self.harness.charm.app].keys()),
                 ["chroot", "endpoints", "password", "uris", "username"],

--- a/tests/unit/test_zookeeper_provider.py
+++ b/tests/unit/test_zookeeper_provider.py
@@ -41,15 +41,6 @@ class TestCluster(unittest.TestCase):
         self.harness.add_relation("database", "application")
         self.harness.begin_with_initial_hooks()
 
-    def print_relation_data(self):
-        print("\n")
-        print(f"{self.harness.charm.client_relation.app_relation=}")
-        print(f"{self.harness.charm.client_relation.client_relations=}")
-        print(f"{self.harness.charm.cluster.relation.data[self.harness.charm.app]=}")
-        print("\n")
-        print(f"{self.provider.client_relations=}")
-        print(f"{self.provider.app_relation=}")
-
     @property
     def provider(self):
         return self.harness.charm.client_relation

--- a/tests/unit/test_zookeeper_provider.py
+++ b/tests/unit/test_zookeeper_provider.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import re
+import unittest
+from ops.charm import CharmBase, RelationBrokenEvent
+from charms.zookeeper.v0.cluster import ZooKeeperCluster
+from charms.zookeeper.v0.zookeeper_provider import ZooKeeperProvider
+from ops.testing import Harness
+import logging
+
+import ops.testing
+
+ops.testing.SIMULATE_CAN_CONNECT = True
+
+logger = logging.getLogger(__name__)
+
+METADATA = """
+    name: zookeeper
+    peers:
+        cluster:
+            interface: cluster
+    provides:
+        database:
+            interface: database-client
+"""
+
+
+class DummyZooKeeperCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.cluster = ZooKeeperCluster(self)
+        self.client_relation = ZooKeeperProvider(self)
+
+
+class TestCluster(unittest.TestCase):
+    def setUp(self):
+        self.harness = Harness(DummyZooKeeperCharm, meta=METADATA)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.add_relation("database", "application")
+        self.harness.begin_with_initial_hooks()
+
+    def print_relation_data(self):
+        print("\n")
+        print(f"{self.harness.charm.client_relation.app_relation=}")
+        print(f"{self.harness.charm.client_relation.client_relations=}")
+        print(f"{self.harness.charm.cluster.relation.data[self.harness.charm.app]=}")
+        print("\n")
+        print(f"{self.provider.client_relations=}")
+        print(f"{self.provider.app_relation=}")
+
+    @property
+    def provider(self):
+        return self.harness.charm.client_relation
+
+    def test_relation_config_new_relation_no_chroot(self):
+        config = self.harness.charm.client_relation.relation_config(
+            relation=self.provider.client_relations[0]
+        )
+        self.assertIsNone(config)
+
+    def test_relation_config_new_relation(self):
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        self.harness.update_relation_data(
+            self.provider.app_relation.id, "zookeeper", {"relation-0": "password"}
+        )
+
+        config = self.harness.charm.client_relation.relation_config(
+            relation=self.provider.client_relations[0]
+        )
+
+        self.assertEqual(
+            config,
+            {"username": "relation-0", "password": "password", "chroot": "/app", "acl": "cdrwa"},
+        )
+
+    def test_relation_config_new_relation_defaults_to_database(self):
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id, "application", {"database": "app"}
+        )
+        self.harness.update_relation_data(
+            self.provider.app_relation.id, "zookeeper", {"relation-0": "password"}
+        )
+
+        config = self.harness.charm.client_relation.relation_config(
+            relation=self.provider.client_relations[0]
+        )
+
+        self.assertEqual(
+            config,
+            {"username": "relation-0", "password": "password", "chroot": "/app", "acl": "cdrwa"},
+        )
+
+    def test_relation_config_new_relation_empty_password(self):
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+
+        config = self.harness.charm.client_relation.relation_config(
+            relation=self.provider.client_relations[0]
+        )
+
+        self.assertEqual(
+            config, {"username": "relation-0", "password": "", "chroot": "/app", "acl": "cdrwa"}
+        )
+
+    def test_relation_config_new_relation_app_permissions(self):
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id,
+            "application",
+            {"chroot": "app", "chroot-acl": "rw"},
+        )
+
+        config = self.harness.charm.client_relation.relation_config(
+            relation=self.provider.client_relations[0]
+        )
+
+        self.assertEqual(
+            config, {"username": "relation-0", "password": "", "chroot": "/app", "acl": "rw"}
+        )
+
+    def test_relation_config_new_relation_skips_relation_broken(self):
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id,
+            "application",
+            {"chroot": "app", "chroot-acl": "rw"},
+        )
+
+        config = self.harness.charm.client_relation.relation_config(
+            relation=self.provider.client_relations[0],
+            event=RelationBrokenEvent(handle="", relation=""),
+        )
+
+        self.assertIsNone(config)
+
+    def test_relations_config_multiple_relations(self):
+        self.harness.add_relation("database", "new_application")
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        self.harness.update_relation_data(
+            self.provider.client_relations[1].id, "new_application", {"chroot": "new_app"}
+        )
+
+        relations_config = self.harness.charm.client_relation.relations_config()
+
+        self.assertEqual(
+            relations_config,
+            {
+                "0": {"username": "relation-0", "password": "", "chroot": "/app", "acl": "cdrwa"},
+                "2": {
+                    "username": "relation-2",
+                    "password": "",
+                    "chroot": "/new_app",
+                    "acl": "cdrwa",
+                },
+            },
+        )
+
+    def test_build_acls(self):
+        self.harness.add_relation("database", "new_application")
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        self.harness.update_relation_data(
+            self.provider.client_relations[1].id,
+            "new_application",
+            {"chroot": "new_app", "chroot-acl": "rw"},
+        )
+
+        acls = self.harness.charm.client_relation.build_acls()
+
+        self.assertEqual(len(acls), 2)
+        self.assertEqual(sorted(acls.keys()), ["/app", "/new_app"])
+        self.assertIsInstance(acls["/app"], list)
+
+        new_app_acl = acls["/new_app"][0]
+
+        self.assertEqual(new_app_acl.acl_list, ["READ", "WRITE"])
+        self.assertEqual(new_app_acl.id.scheme, "sasl")
+        self.assertEqual(new_app_acl.id.id, "relation-2")
+
+    def test_relations_config_values_for_key(self):
+        self.harness.add_relation("database", "new_application")
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        self.harness.update_relation_data(
+            self.provider.client_relations[1].id,
+            "new_application",
+            {"chroot": "new_app", "chroot-acl": "rw"},
+        )
+
+        config_values = self.harness.charm.client_relation.relations_config_values_for_key(
+            key="username"
+        )
+
+        self.assertEqual(config_values, {"relation-2", "relation-0"})
+
+    def test_is_child_of(self):
+        chroot = "/gandalf/the/white"
+        chroots = {"/gandalf", "/saruman"}
+
+        self.assertTrue(
+            self.harness.charm.client_relation._is_child_of(path=chroot, chroots=chroots)
+        )
+
+    def test_apply_relation_data(self):
+        self.harness.set_leader(True)
+        self.harness.add_relation("database", "new_application")
+        self.harness.update_relation_data(
+            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        self.harness.update_relation_data(
+            self.provider.client_relations[1].id,
+            "new_application",
+            {"chroot": "new_app", "chroot-acl": "rw"},
+        )
+        self.harness.update_relation_data(
+            self.provider.app_relation.id,
+            "zookeeper/0",
+            {"private-address": "treebeard", "state": "started"},
+        )
+        self.harness.add_relation_unit(self.provider.app_relation.id, "zookeeper/1")
+        self.harness.update_relation_data(
+            self.provider.app_relation.id,
+            "zookeeper/1",
+            {"private-address": "shelob", "state": "ready"},
+        )
+        self.harness.add_relation_unit(self.provider.app_relation.id, "zookeeper/2")
+        self.harness.update_relation_data(
+            self.provider.app_relation.id,
+            "zookeeper/2",
+            {"private-address": "balrog", "state": "started"},
+        )
+
+        self.harness.charm.client_relation.apply_relation_data()
+
+        passwords = []
+        usernames = []
+        for relation in self.provider.client_relations:
+
+            # checking existance of all necessary keys
+            self.assertEqual(
+                sorted(relation.data[self.harness.charm.app].keys()),
+                ["chroot", "endpoints", "password", "uris", "username"],
+            )
+
+            # checking unique passwords and usernames for all relations
+            self.assertNotIn(relation.data[self.harness.charm.app]["password"], passwords)
+            self.assertNotIn(relation.data[self.harness.charm.app]["username"], usernames)
+
+            # checking multiple endpoints and uris
+            self.assertEqual(len(relation.data[self.harness.charm.app]["endpoints"].split(",")), 2)
+            self.assertEqual(len(relation.data[self.harness.charm.app]["uris"].split(",")), 2)
+
+            for uri in relation.data[self.harness.charm.app]["uris"].split(","):
+                # checking chroot in uri
+                self.assertTrue(uri.endswith(relation.data[self.harness.charm.app]["chroot"]))
+                # checking client_port in uri
+                self.assertTrue(re.search(r":[\d]+\/", uri))
+
+            passwords.append(relation.data[self.harness.charm.app]["password"])
+            usernames.append(relation.data[self.harness.charm.app]["username"])

--- a/tests/unit/test_zookeeper_provider.py
+++ b/tests/unit/test_zookeeper_provider.py
@@ -65,7 +65,13 @@ class TestCluster(unittest.TestCase):
 
         self.assertEqual(
             config,
-            {"username": "relation-0", "password": "password", "chroot": "/app", "acl": "cdrwa"},
+            {
+                "username": "relation-0",
+                "password": "password",
+                "chroot": "/app",
+                "acl": "cdrwa",
+                "jaas_user": 'user_relation-0="password"',
+            },
         )
 
     def test_relation_config_new_relation_defaults_to_database(self):
@@ -82,7 +88,13 @@ class TestCluster(unittest.TestCase):
 
         self.assertEqual(
             config,
-            {"username": "relation-0", "password": "password", "chroot": "/app", "acl": "cdrwa"},
+            {
+                "username": "relation-0",
+                "password": "password",
+                "chroot": "/app",
+                "acl": "cdrwa",
+                "jaas_user": 'user_relation-0="password"',
+            },
         )
 
     def test_relation_config_new_relation_empty_password(self):
@@ -95,7 +107,14 @@ class TestCluster(unittest.TestCase):
         )
 
         self.assertEqual(
-            config, {"username": "relation-0", "password": "", "chroot": "/app", "acl": "cdrwa"}
+            config,
+            {
+                "username": "relation-0",
+                "password": "",
+                "chroot": "/app",
+                "acl": "cdrwa",
+                "jaas_user": 'user_relation-0=""',
+            },
         )
 
     def test_relation_config_new_relation_app_permissions(self):
@@ -110,7 +129,14 @@ class TestCluster(unittest.TestCase):
         )
 
         self.assertEqual(
-            config, {"username": "relation-0", "password": "", "chroot": "/app", "acl": "rw"}
+            config,
+            {
+                "username": "relation-0",
+                "password": "",
+                "chroot": "/app",
+                "acl": "rw",
+                "jaas_user": 'user_relation-0=""',
+            },
         )
 
     def test_relation_config_new_relation_skips_relation_broken(self):
@@ -141,12 +167,19 @@ class TestCluster(unittest.TestCase):
         self.assertEqual(
             relations_config,
             {
-                "0": {"username": "relation-0", "password": "", "chroot": "/app", "acl": "cdrwa"},
+                "0": {
+                    "username": "relation-0",
+                    "password": "",
+                    "chroot": "/app",
+                    "acl": "cdrwa",
+                    "jaas_user": 'user_relation-0=""',
+                },
                 "2": {
                     "username": "relation-2",
                     "password": "",
                     "chroot": "/new_app",
                     "acl": "cdrwa",
+                    "jaas_user": 'user_relation-2=""',
                 },
             },
         )
@@ -237,7 +270,7 @@ class TestCluster(unittest.TestCase):
             # checking existence of all necessary keys
             self.assertEqual(
                 sorted(relation.data[self.harness.charm.app].keys()),
-                ["chroot", "endpoints", "password", "uris", "username"],
+                sorted(["chroot", "endpoints", "password", "uris", "username"]),
             )
 
             # checking unique passwords and usernames for all relations

--- a/tests/unit/test_zookeeper_provider.py
+++ b/tests/unit/test_zookeeper_provider.py
@@ -22,7 +22,7 @@ METADATA = """
         cluster:
             interface: cluster
     provides:
-        database:
+        zookeeper:
             interface: zookeeper
 """
 
@@ -34,11 +34,11 @@ class DummyZooKeeperCharm(CharmBase):
         self.client_relation = ZooKeeperProvider(self)
 
 
-class TestCluster(unittest.TestCase):
+class TestProvider(unittest.TestCase):
     def setUp(self):
         self.harness = Harness(DummyZooKeeperCharm, meta=METADATA)
         self.addCleanup(self.harness.cleanup)
-        self.harness.add_relation("database", "application")
+        self.harness.add_relation("zookeeper", "application")
         self.harness.begin_with_initial_hooks()
 
     @property
@@ -154,7 +154,7 @@ class TestCluster(unittest.TestCase):
         self.assertIsNone(config)
 
     def test_relations_config_multiple_relations(self):
-        self.harness.add_relation("database", "new_application")
+        self.harness.add_relation("zookeeper", "new_application")
         self.harness.update_relation_data(
             self.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
@@ -185,7 +185,7 @@ class TestCluster(unittest.TestCase):
         )
 
     def test_build_acls(self):
-        self.harness.add_relation("database", "new_application")
+        self.harness.add_relation("zookeeper", "new_application")
         self.harness.update_relation_data(
             self.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
@@ -208,7 +208,7 @@ class TestCluster(unittest.TestCase):
         self.assertEqual(new_app_acl.id.id, "relation-2")
 
     def test_relations_config_values_for_key(self):
-        self.harness.add_relation("database", "new_application")
+        self.harness.add_relation("zookeeper", "new_application")
         self.harness.update_relation_data(
             self.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
@@ -242,7 +242,7 @@ class TestCluster(unittest.TestCase):
 
     def test_apply_relation_data(self):
         self.harness.set_leader(True)
-        self.harness.add_relation("database", "new_application")
+        self.harness.add_relation("zookeeper", "new_application")
         self.harness.update_relation_data(
             self.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
@@ -282,7 +282,6 @@ class TestCluster(unittest.TestCase):
             )
         )
 
-        
         app_data = self.harness.charm.cluster.relation.data[self.harness.charm.app]
         passwords = []
         usernames = []
@@ -295,7 +294,7 @@ class TestCluster(unittest.TestCase):
 
             username = relation.data[self.harness.charm.app]["username"]
             password = relation.data[self.harness.charm.app]["password"]
-            
+
             # checking ZK app data got updated
             self.assertIn(username, app_data)
             self.assertEqual(password, app_data.get(username, None))

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+        -m pytest tests/unit/test_zookeeper_provider.py --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
 
 [testenv:integration]

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest tests/unit/test_zookeeper_provider.py --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
 
 [testenv:integration]

--- a/tox.ini
+++ b/tox.ini
@@ -89,4 +89,4 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -vv --no-header --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest tests/integration/test_zookeeper_provider.py -vv --no-header --tb native --model test --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
### NOTE

This is an intermediary PR, so please skip RollingOps and please focus on `client.py` and `zookeeper_provider.py` changes.
This is also my first time doing a client relation, so please let me know if I've done a really silly pattern.

## Changes Made

- `feat: add provider relation`. This manages the creation and removal of users from ZK auth config
- `feat: add rolling ops`. This will eventually be used for rolling restarts on `relation_joined/broken` events when new clients alter the relations
- `test: unit tests for znode methods and provider library`


## TODO
- Implement Rolling Restarts of ZK units upon requisite relation events, updating their `JAAS` file
- Integration tests with a dummy charm. Unit test coverage is pretty strong, but I'm sure there are issues I've missed having not yet deployed it, so I will address those while this PR is in review.
