### PR TITLE
fix: resolve bug that stopped re-deployed zookeeper apps in the same model from starting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,8 @@
 name: Testing
 
 on:
-  push:
-    branches:
-      - main
-    pull_request:
+  pull_request:
+
 
 jobs:
   lint:

--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -74,7 +74,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 logger = logging.getLogger(__name__)
@@ -262,7 +262,7 @@ class ZooKeeperManager:
             raise MembersSyncingError("Unable to remove members - some members are syncing")
 
         for member in members:
-            member_id = re.findall(r"server.([1-9]+)", member)[0]
+            member_id = re.findall(r"server.([0-9]+)", member)[0]
             with ZooKeeperClient(
                 host=self.leader,
                 client_port=self.client_port,

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,7 +5,6 @@
 """Charmed Machine Operator for Apache ZooKeeper."""
 
 import logging
-import time
 
 from charms.kafka.v0.kafka_snap import KafkaSnap
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
@@ -107,7 +106,6 @@ class ZooKeeperCharm(CharmBase):
         except (NotUnitTurnError, UnitNotFoundError, NoPasswordError) as e:
             logger.info(str(e))
             self.unit.status = self.cluster.status
-            time.sleep(2)  # accounts for when defers are used up before leader updates config
             event.defer()
             return
 
@@ -152,8 +150,8 @@ class ZooKeeperCharm(CharmBase):
             current_value = self.cluster.relation.data[self.app].get(str(unit_id), None)
 
             # sets to "added" for init quorum leader, if not already exists
-            # may already exist if during the case of a failover of unit 0
-            if unit_id == 0:
+            # may already exist if during the case of a failover of the first unit
+            if unit_id == self.cluster.lowest_unit_id:
                 self.cluster.relation.data[self.app].update(
                     {str(unit_id): current_value or "added"}
                 )

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -25,13 +25,9 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
-@pytest.fixture
-async def charm(ops_test: OpsTest):
-    return await ops_test.build_charm(".")
-
-
 @pytest.mark.abort_on_fail
-async def test_deploy_active(ops_test: OpsTest, charm):
+async def test_deploy_active(ops_test: OpsTest):
+    charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
@@ -133,9 +129,10 @@ async def test_kill_juju_leader_restart(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_same_model_application_deploys(ops_test: OpsTest, charm):
+async def test_same_model_application_deploys(ops_test: OpsTest):
     """Ensures that re-deployments of the charm starts on the same model."""
     await asyncio.gather(ops_test.model.applications[APP_NAME].remove())
+    charm = await ops_test.build_charm(".")
     time.sleep(10)
     await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -58,7 +58,7 @@ class TestClient(unittest.TestCase):
         result, version = client.config
         servers = [server.split("=")[0] for server in result]
 
-        self.assertEquals(version, 4294967296)
+        self.assertEqual(version, 4294967296)
         self.assertIn("server.1", servers)
         self.assertIn("server.2", servers)
 
@@ -144,6 +144,27 @@ class TestManager(unittest.TestCase):
 
         reconfig.assert_called_with(
             joining=None, leaving="2", new_members=None, from_config=4294967296
+        )
+
+    @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())
+    @patch.object(DummyClient, "reconfig")
+    def test_remove_members_handles_zeroes(self, reconfig, _):
+        zk = ZooKeeperManager(
+            hosts=[
+                "server.1=bilbo.baggins",
+                "server.10=pippin.took",
+                "server.300=merry.brandybuck",
+            ],
+            username="",
+            password="",
+        )
+        zk.remove_members(["server.2=sam.gamgee"])
+        reconfig.assert_called_with(
+            joining=None, leaving="2", new_members=None, from_config=4294967296
+        )
+        zk.remove_members(["server.300=merry.brandybuck"])
+        reconfig.assert_called_with(
+            joining=None, leaving="300", new_members=None, from_config=4294967296
         )
 
     @patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient())

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,6 @@ commands =
     /bin/bash -ec "juju add-model zookeeper"
     /bin/bash -ec "charmcraft pack"
     /bin/bash -ec "juju deploy ./*.charm -n 3"
-    /bin/bash -ec "cd tests/integration/app-charm && charmcraft pack && juju deploy ./*.charm -n 1"
-    /bin/bash -ec "juju relate application zookeeper"
 
 [testenv:fmt]
 description = Apply coding style standards to code


### PR DESCRIPTION
## Changes Made

- `fix: units no longer need to init at '0'`
    - Previously ZK would fail after a redeploy, as it couldn't find unit 0 in the relation data
    - Added `lowest_unit_id` search, so that if unit 3,4,5 is deployed, 3 will be found lowest and start 
- `fix: update faulty regex not looking for '0'`
    - This didn't cause too many issues, but meant that the relation data would update unit '1' instead of unit '10'