### PR TITLE
Add config_changed event handler

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -131,6 +131,12 @@ class ZooKeeperCharm(CharmBase):
         self.cluster.relation.data[self.unit].update({"state": "started"})
 
     def _on_config_changed(self, event):
+        """Handler for the `config-changed` event.
+
+        This includes:
+            - Writing config to config files\
+            - Restarting zookeeper service
+        """
         self.snap.write_properties(
             properties=self.config["zookeeper-properties"], property_label="zookeeper"
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -134,6 +134,7 @@ class ZooKeeperCharm(CharmBase):
         self.snap.write_properties(
             properties=self.config["zookeeper-properties"], property_label="zookeeper"
         )
+        self.snap.restart_snap_service("zookeeper")
 
     def _on_cluster_relation_updated(self, event: EventBase) -> None:
         """Handler for events triggered by changing units.

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,6 +46,7 @@ class ZooKeeperCharm(CharmBase):
         self.framework.observe(
             getattr(self.on, "leader_elected"), self._on_cluster_relation_updated
         )
+        self.framework.observe(getattr(self.on, "config_changed"), self._on_config_changed)
         self.framework.observe(
             getattr(self.on, "cluster_relation_changed"), self._on_cluster_relation_updated
         )
@@ -128,6 +129,11 @@ class ZooKeeperCharm(CharmBase):
         # unit flags itself as 'started' so it can be retrieved by the leader
         self.cluster.relation.data[self.unit].update(unit_config)
         self.cluster.relation.data[self.unit].update({"state": "started"})
+
+    def _on_config_changed(self, event):
+        self.snap.write_properties(
+            properties=self.config["zookeeper-properties"], property_label="zookeeper"
+        )
 
     def _on_cluster_relation_updated(self, event: EventBase) -> None:
         """Handler for events triggered by changing units.


### PR DESCRIPTION
This PR handles the charms config_changed events and allows for changing the charm config outside of install time. 