### PR TITLE
Add snap-channel config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,11 @@ options:
     description: "Amount of time, in ticks, to allow followers to connect and sync to a leader."
     type: int
     default: 5
+  snap-channel:
+    type: string
+    default: "rock/edge"
+    description: |
+      "Kafka snap channel to install and track."
   sync-limit:
     description: "Amount of time, in ticks, to allow followers to sync with ZooKeeper."
     type: int

--- a/lib/charms/kafka/v0/kafka_snap.py
+++ b/lib/charms/kafka/v0/kafka_snap.py
@@ -88,7 +88,7 @@ class KafkaSnap:
         self.snap_config_path = SNAP_CONFIG_PATH
         self.kafka = snap.SnapCache()["kafka"]
 
-    def install(self) -> bool:
+    def install(self, channel) -> bool:
         """Loads the Kafka snap from LP, returning a StatusBase for the Charm to set.
 
         If fails with expected errors, it will block the KafkaSnap instance from executing
@@ -103,8 +103,8 @@ class KafkaSnap:
             cache = snap.SnapCache()
             kafka = cache["kafka"]
 
-            if not kafka.present:
-                kafka.ensure(snap.SnapState.Latest, channel="rock/edge")
+            if True: #not kafka.present:
+                kafka.ensure(snap.SnapState.Latest, channel=channel)
 
             self.kafka = kafka
             return True

--- a/lib/charms/kafka/v0/kafka_snap.py
+++ b/lib/charms/kafka/v0/kafka_snap.py
@@ -103,7 +103,7 @@ class KafkaSnap:
             cache = snap.SnapCache()
             kafka = cache["kafka"]
 
-            if True: #not kafka.present:
+            if not kafka.present:
                 kafka.ensure(snap.SnapState.Latest, channel=channel)
 
             self.kafka = kafka
@@ -111,6 +111,18 @@ class KafkaSnap:
         except (snap.SnapError, apt.PackageNotFoundError) as e:
             logger.error(str(e))
             return False
+
+    def refresh(self, channel):
+        """Refreshes the Kafka snap to the specified channel.
+
+        Args:
+            channel: The desired snap channel for the kafka charm.
+                i.e. latest/stable, rock/edge, etc.
+        """
+        try:
+            self.kafka.ensure(snap.SnapState.Latest, channel=channel)
+        except snap.SnapError as e:
+            logger.exception(string(e))
 
     def start_snap_service(self, snap_service: str) -> bool:
         """Starts snap service process.

--- a/src/charm.py
+++ b/src/charm.py
@@ -138,7 +138,7 @@ class ZooKeeperCharm(CharmBase):
             - Writing config to config files\
             - Restarting zookeeper service
         """
-        self.snap.install(self.config["snap-channel"])
+        self.snap.refresh(self.config["snap-channel"])
         self.snap.write_properties(
             properties=self.zookeeper_config.create_properties(self.config),
             property_label="zookeeper",

--- a/src/charm.py
+++ b/src/charm.py
@@ -68,7 +68,7 @@ class ZooKeeperCharm(CharmBase):
 
         # if any snap method calls fail, Snap.status is set to BlockedStatus
         # non-idempotent commands (e.g setting properties) will no longer run, returning None
-        if self.snap.install():
+        if self.snap.install(self.config["snap-channel"]):
             self.snap.write_properties(
                 properties=self.zookeeper_config.create_properties(self.config),
                 property_label="zookeeper",
@@ -138,6 +138,7 @@ class ZooKeeperCharm(CharmBase):
             - Writing config to config files\
             - Restarting zookeeper service
         """
+        self.snap.install(self.config["snap-channel"])
         self.snap.write_properties(
             properties=self.zookeeper_config.create_properties(self.config),
             property_label="zookeeper",


### PR DESCRIPTION
Add the ability to install a specific snap channel.

This will be helpful with creating bundles in the future as you will be able to pin both the charm and the snap versions.  With the current PR, the snap-channel tracks `rocks/edge` and can update the snap version post-deploy.  This will be far more useful when there are actually pinned snap channels.

The aim of this draft PR is to help facilitate discussions on how to proceed with controlling the versioning of snaps and if in-place upgrades should be supported for a clustered application.