### PR TITLE
test: check that ACL are set correctly when you relate with an application

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import json
-import logging
 import re
 from pathlib import Path
 from subprocess import PIPE, check_output
@@ -16,8 +15,6 @@ from pytest_operator.plugin import OpsTest
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-
-logger = logging.getLogger(__name__)
 
 
 def get_password(model_full_name: str) -> str:
@@ -199,7 +196,6 @@ def check_acl_permission(host: str, password: str, folder: str, username: str = 
     kc.start()
     try:
         value, _ = kc.get_acls_async(f"/{folder}") or None, None
-        logger.info(f"Value : {value}")
         stored_value = None
         if value:
             stored_value = value.get()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -246,20 +246,10 @@ def get_relation_password(model_full_name: str, unit: str, app_name: str):
     raise Exception("No relation found!")
 
 
-def get_application_hosts(model_full_name: str, units: List[str]) -> List[str]:
-    """Retrieves from the leader the ip addresses of the containers."""
+async def get_application_hosts(ops_test: OpsTest, app_name: str, units: List[str]) -> List[str]:
+    """Retrieves the ip addresses of the containers."""
     hosts = []
+    status = await ops_test.model.get_status()  # noqa: F821
     for unit in units:
-        # check for leadership
-        res = _get_show_unit_json(model_full_name=model_full_name, unit=unit)
-        if res[unit]["leader"] is True:
-            if "relation-info" in res[unit]:
-                relations = res[unit]["relation-info"]
-                for relation in relations:
-                    if relation["endpoint"] == "cluster":
-                        if "local-unit" in relation:
-                            hosts.append(relation["local-unit"]["data"]["private-address"])
-                        if "related-units" in relation:
-                            for _, r_data in relation["related-units"].items():
-                                hosts.append(r_data["data"]["private-address"])
+        hosts.append(status["applications"][app_name]["units"][f"{unit}"]["public-address"])
     return hosts

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -219,30 +219,12 @@ def get_relation_id(model_full_name: str, unit: str, app_name: str):
     raise Exception("No relation found!")
 
 
-def get_relation_username(model_full_name: str, unit: str, app_name: str):
+def get_relation_data(model_full_name: str, unit: str, app_name: str):
     show_unit = _get_show_unit_json(model_full_name=model_full_name, unit=unit)
     d_relations = show_unit[unit]["relation-info"]
     for relation in d_relations:
         if relation["endpoint"] == app_name:
-            return relation["application-data"]["username"]
-    raise Exception("No relation found!")
-
-
-def get_relation_chroot(model_full_name: str, unit: str, app_name: str):
-    show_unit = _get_show_unit_json(model_full_name=model_full_name, unit=unit)
-    d_relations = show_unit[unit]["relation-info"]
-    for relation in d_relations:
-        if relation["endpoint"] == app_name:
-            return relation["application-data"]["chroot"]
-    raise Exception("No relation found!")
-
-
-def get_relation_password(model_full_name: str, unit: str, app_name: str):
-    show_unit = _get_show_unit_json(model_full_name=model_full_name, unit=unit)
-    d_relations = show_unit[unit]["relation-info"]
-    for relation in d_relations:
-        if relation["endpoint"] == app_name:
-            return relation["application-data"]["password"]
+            return relation["application-data"]
     raise Exception("No relation found!")
 
 

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -14,9 +14,6 @@ from tests.integration.helpers import (
     get_application_hosts,
     get_password,
     get_relation_chroot,
-    get_relation_id,
-    get_relation_password,
-    get_relation_username,
     ping_servers,
 )
 
@@ -53,20 +50,8 @@ async def test_deploy_charms_relate_active(ops_test: OpsTest):
 
     application_unit = ops_test.model.applications[DUMMY_NAME_1].units[0]
     # Get relation info from the related application
-    d_relation_id = get_relation_id(
-        model_full_name=ops_test.model_full_name, unit=application_unit.name, app_name=APP_NAME
-    )
-    d_username = get_relation_username(
-        model_full_name=ops_test.model_full_name, unit=application_unit.name, app_name=APP_NAME
-    )
     d_chroot = get_relation_chroot(
         model_full_name=ops_test.model_full_name, unit=application_unit.name, app_name=APP_NAME
-    )
-    d_password = get_relation_password(
-        model_full_name=ops_test.model_full_name, unit=application_unit.name, app_name=APP_NAME
-    )
-    logger.info(
-        f"relation-id: {d_relation_id} | username: {d_username} | chroot: {d_chroot} | password: {d_password}"
     )
     # Get the super password
     super_password = get_password(model_full_name=ops_test.model_full_name)

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -13,7 +13,7 @@ from tests.integration.helpers import (
     check_jaas_config,
     get_application_hosts,
     get_password,
-    get_relation_chroot,
+    get_relation_data,
     ping_servers,
 )
 
@@ -49,8 +49,8 @@ async def test_deploy_charms_relate_active(ops_test: OpsTest):
     assert len(ops_test.model.applications[DUMMY_NAME_1].units) == 1
 
     application_unit = ops_test.model.applications[DUMMY_NAME_1].units[0]
-    # Get relation info from the related application
-    d_chroot = get_relation_chroot(
+    # Get relation data
+    relation_data = get_relation_data(
         model_full_name=ops_test.model_full_name, unit=application_unit.name, app_name=APP_NAME
     )
     # Get the super password
@@ -60,7 +60,7 @@ async def test_deploy_charms_relate_active(ops_test: OpsTest):
     hosts = await get_application_hosts(ops_test=ops_test, app_name=APP_NAME, units=units)
     # Check acl permission for the application on each Zookeeper host
     for host in hosts:
-        check_acl_permission(host, super_password, d_chroot)
+        check_acl_permission(host, super_password, relation_data["chroot"])
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -57,7 +57,7 @@ async def test_deploy_charms_relate_active(ops_test: OpsTest):
     super_password = get_password(model_full_name=ops_test.model_full_name)
     units = [u.name for u in ops_test.model.applications[APP_NAME].units]
     # Get hosts where Zookeeper is deployed
-    hosts = get_application_hosts(model_full_name=ops_test.model_full_name, units=units)
+    hosts = await get_application_hosts(ops_test=ops_test, app_name=APP_NAME, units=units)
     # Check acl permission for the application on each Zookeeper host
     for host in hosts:
         check_acl_permission(host, super_password, d_chroot)


### PR DESCRIPTION
This PR includes a check that verifies that ACL permissions are granted when Zookeeper relates with another application.