### PR TITLE
fix: ensure provided port is updated if SSL is enabled

### DIFF
--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -76,7 +76,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 3
 
 
 logger = logging.getLogger(__name__)

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,6 +253,9 @@ class ZooKeeperCharm(CharmBase):
                 logger.info("ZooKeeper cluster running without quorum encryption")
                 self.cluster.relation.data[self.app].update({"quorum": "non-ssl", "upgrading": ""})
 
+        # attempt update of client relation data in case port updated
+        self.provider.apply_relation_data(event)
+
     def add_init_leader(self) -> None:
         """Adds the first leader server to the relation data for other units to ack."""
         if not self.unit.is_leader():

--- a/src/charm.py
+++ b/src/charm.py
@@ -246,7 +246,7 @@ class ZooKeeperCharm(CharmBase):
             return
 
         # default startup without ssl relation
-        if not (self.cluster.stale_quorum and self.tls.enabled and self.tls.upgrading):
+        if not self.cluster.stale_quorum and not self.tls.enabled and not self.tls.upgrading:
             if not self.cluster.quorum:  # avoids multiple loglines
                 logger.info("ZooKeeper cluster running with non-SSL quorum")
 

--- a/src/provider.py
+++ b/src/provider.py
@@ -229,9 +229,16 @@ class ZooKeeperProvider(Object):
             relation_data["password"] = config["password"] or generate_password()
             relation_data["chroot"] = config["chroot"]
             relation_data["endpoints"] = ",".join(list(hosts))
+
+            if self.charm.tls.quorum == "ssl":
+                relation_data["ssl"] = "enabled"
+                port = self.charm.cluster.secure_client_port
+            else:
+                relation_data["ssl"] = "disabled"
+                port = self.charm.cluster.client_port
+
             relation_data["uris"] = (
-                ",".join([f"{host}:{self.charm.cluster.client_port}" for host in hosts])
-                + config["chroot"]
+                ",".join([f"{host}:{port}" for host in hosts]) + config["chroot"]
             )
 
             self.app_relation.data[self.charm.app].update(

--- a/src/provider.py
+++ b/src/provider.py
@@ -230,7 +230,7 @@ class ZooKeeperProvider(Object):
             relation_data["chroot"] = config["chroot"]
             relation_data["endpoints"] = ",".join(list(hosts))
 
-            if self.charm.tls.quorum == "ssl":
+            if self.charm.cluster.quorum == "ssl":
                 relation_data["ssl"] = "enabled"
                 port = self.charm.cluster.secure_client_port
             else:
@@ -255,6 +255,11 @@ class ZooKeeperProvider(Object):
         Args:
             event (optional): used for checking `RelationBrokenEvent`
         """
+        # avoids failure from early relation
+        if not self.charm.cluster.quorum:
+            event.defer()
+            return
+
         if self.charm.unit.is_leader():
             try:
                 self.update_acls(event=event)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -303,7 +303,7 @@ class TestProvider(unittest.TestCase):
             # checking existence of all necessary keys
             self.assertEqual(
                 sorted(relation.data[self.harness.charm.app].keys()),
-                sorted(["chroot", "endpoints", "password", "uris", "username"]),
+                sorted(["chroot", "endpoints", "password", "ssl", "uris", "username"]),
             )
 
             username = relation.data[self.harness.charm.app]["username"]


### PR DESCRIPTION
## Changes Made
#### `fix: ensure provided port is updated if SSL is enabled`
- This was mostly an omission from previous SSL PR
- Also added an `ssl` field, to inform clients that they should be using an SSL port. Intended usage of this might be something like:
    - `if 'ssl' in relation.data and not self.signed_cert: BlockedStatus` 
#### `fix: ensure too-fast relation doesn't fail`
- When ZK and a client was deployed and related simultaneously, ZK would attempt to handle the `client_relation` events before properly starting up
- This caused several issues, but mostly it locked up due to attempting to find quorum leader, before quorum had been established
- Fixed by checking for `quorum` relation data flag before handling provider relation events