### PR TITLE
chore: ensure portUnification+sslQuorum step is not missed

### DIFF
--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -249,7 +249,7 @@ class TestProvider(unittest.TestCase):
 
         for relation in self.provider.client_relations:
             uris = relation.data[self.harness.charm.app].get("uris", "")
-            ssl = relation.data[self.harness.charm.app].get("ssl", "")
+            ssl = relation.data[self.harness.charm.app].get("tls", "")
 
             self.assertIn(str(self.harness.charm.cluster.secure_client_port), uris)
             self.assertEqual(ssl, "enabled")
@@ -270,7 +270,7 @@ class TestProvider(unittest.TestCase):
 
         for relation in self.provider.client_relations:
             uris = relation.data[self.harness.charm.app].get("uris", "")
-            ssl = relation.data[self.harness.charm.app].get("ssl", "")
+            ssl = relation.data[self.harness.charm.app].get("tls", "")
 
             self.assertIn(str(self.harness.charm.cluster.client_port), uris)
             self.assertEqual(ssl, "disabled")
@@ -339,7 +339,7 @@ class TestProvider(unittest.TestCase):
             # checking existence of all necessary keys
             self.assertEqual(
                 sorted(relation.data[self.harness.charm.app].keys()),
-                sorted(["chroot", "endpoints", "password", "ssl", "uris", "username"]),
+                sorted(["chroot", "endpoints", "password", "tls", "uris", "username"]),
             )
 
             username = relation.data[self.harness.charm.app]["username"]


### PR DESCRIPTION
## Changes Made
#### `chore: use tls flag over ssl flag`
- Update to align with other database charm relation interfaces using the same flag
#### `fix: ensure quorum not lost during tls relations`
- Previous implementation mistakenly skipped the `portUnification`+`sslQuorum` step when switching to SSL quorum encryption, sometimes resulting in loss of quorum
    - This had a knock-on effect, where only a single-server quorum was left, and when a client related to the ZK app, that server would restart and not be part of a quorum 
    - Fixed by setting unit + app level relation data checking that all units are at the correct stage of an encryption change, before doing anything else
- Previous implementation mistakenly overwrote the dynamic property set in `zookeeper.properties` to set new SSL-specific config, sometimes resulting in loss of quorum
    - This resulted in servers sometimes not being aware of other server members after restarting, losing quorum  
    - Fixed by checking current `dynamicConfigPath` on the server, and appending it to `zookeeper.properties` during property update