### PR TITLE
chore: use pytest for all unit-tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops >= 1.5.3
+ops >= 1.5.2
 kazoo >= 2.8.0
 pure-sasl >= 0.6.2
 tenacity >= 8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops >= 1.5.0
+ops >= 1.5.3
 kazoo >= 2.8.0
 pure-sasl >= 0.6.2
 tenacity >= 8.0.1

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -14,10 +14,6 @@ from charms.zookeeper.v0.client import (
     ZooKeeperManager,
 )
 from kazoo.client import logging
-from ops.testing import Harness
-
-from charm import ZooKeeperCharm
-from literals import CHARM_KEY, PEER
 
 logger = logging.getLogger(__name__)
 
@@ -63,16 +59,6 @@ class DummyClient:
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
 METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
-
-
-@pytest.fixture(scope="function")
-def harness():
-    harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness._update_config({"init-limit": "5", "sync-limit": "2", "tick-time": "2000"})
-    harness.begin()
-    return harness
 
 
 def test_config():

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2,292 +2,317 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 import re
-import unittest
+from pathlib import Path
 
-import ops.testing
-from ops.charm import CharmBase
+import pytest
+import yaml
 from ops.model import Unit
 from ops.testing import Harness
 
-from cluster import UnitNotFoundError, ZooKeeperCluster
+from charm import ZooKeeperCharm
+from cluster import UnitNotFoundError
+from literals import CHARM_KEY, PEER
 
-ops.testing.SIMULATE_CAN_CONNECT = True
+logger = logging.getLogger(__name__)
 
-
-METADATA = """
-    name: zookeeper
-    peers:
-        cluster:
-            interface: cluster
-"""
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
 
-class DummyZooKeeperCharm(CharmBase):
-    def __init__(self, *args):
-        super().__init__(*args)
-        self.cluster = ZooKeeperCluster(self)
+@pytest.fixture
+def harness():
+    harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
+    harness.add_relation("restart", CHARM_KEY)
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness._update_config({"init-limit": "5", "sync-limit": "2", "tick-time": "2000"})
+    harness.begin()
+    return harness
 
 
-class TestCluster(unittest.TestCase):
-    def setUp(self):
-        self.harness = Harness(DummyZooKeeperCharm, meta=METADATA)
-        self.addCleanup(self.harness.cleanup)
-        self.relation_id = self.harness.add_relation("cluster", "cluster")
-        self.harness.begin_with_initial_hooks()
+def test_peer_units_contains_unit(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    assert len(harness.charm.cluster.peer_units) == 2
 
-    @property
-    def cluster(self):
-        return self.harness.charm.cluster
 
-    def test_peer_units_contains_unit(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
+def test_started_units_ignores_ready_units(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"state": "ready"}
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"state": "started"}
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/3", {"state": "started"}
+    )
 
-        self.assertEqual(len(self.cluster.peer_units), 2)
+    assert len(harness.charm.cluster.started_units) == 2
 
-    def test_started_units_ignores_ready_units(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.update_relation_data(self.relation_id, "zookeeper/1", {"state": "ready"})
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(self.relation_id, "zookeeper/2", {"state": "started"})
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/3")
-        self.harness.update_relation_data(self.relation_id, "zookeeper/3", {"state": "started"})
 
-        self.assertEqual(len(self.cluster.started_units), 2)
+def test_get_unit_id(harness):
+    assert harness.charm.cluster.get_unit_id(harness.charm.unit) == 0
 
-    def test_get_unit_id(self):
-        self.assertEqual(self.harness.charm.cluster.get_unit_id(self.harness.charm.unit), 0)
 
-    def test_get_unit_from_id_succeeds(self):
-        unit = self.cluster.get_unit_from_id(0)
+def test_get_unit_from_id_succeeds(harness):
+    unit = harness.charm.cluster.get_unit_from_id(0)
 
-        self.assertTrue(isinstance(unit, Unit))
+    assert isinstance(unit, Unit)
 
-    def test_get_unit_from_id_raises(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
 
-        with self.assertRaises(UnitNotFoundError):
-            self.cluster.get_unit_from_id(100)
+def test_get_unit_from_id_raises(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
 
-    def test_unit_config_raises_for_missing_unit(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
+    with pytest.raises(UnitNotFoundError):
+        harness.charm.cluster.get_unit_from_id(100)
 
-        with self.assertRaises(UnitNotFoundError):
-            self.cluster.get_unit_from_id(100)
 
-    def test_unit_config_succeeds_for_id(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/1", {"private-address": "treebeard"}
-        )
+def test_unit_config_raises_for_missing_unit(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
 
-        self.cluster.unit_config(unit=1)
+    with pytest.raises(UnitNotFoundError):
+        harness.charm.cluster.get_unit_from_id(100)
 
-    def test_unit_config_succeeds_for_unit(self):
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
 
-        self.cluster.unit_config(self.harness.charm.unit)
+def test_unit_config_succeeds_for_id(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "treebeard"}
+    )
 
-    def test_unit_config_has_all_keys(self):
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
-        config = self.cluster.unit_config(0)
+    harness.charm.cluster.unit_config(unit=1)
 
-        self.assertEqual(
-            set(config.keys()),
-            set(["host", "server_string", "server_id", "unit_id", "unit_name", "state"]),
-        )
 
-    def test_unit_config_server_string_format(self):
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
-        server_string = self.cluster.unit_config(0)["server_string"]
-        split_string = re.split("=|:|;", server_string)
+def test_unit_config_succeeds_for_unit(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
 
-        self.assertEqual(len(split_string), 7)
-        self.assertIn("treebeard", split_string)
+    harness.charm.cluster.unit_config(harness.charm.unit)
 
-    def test_get_updated_servers(self):
-        added_servers = [
-            "server.2=gandalf.the.grey",
-        ]
-        removed_servers = [
-            "server.2=gandalf.the.grey",
-            "server.3=in.a.hole.in.the.ground.there.lived.a:hobbit",
-        ]
-        updated_servers = self.cluster._get_updated_servers(
-            added_servers=added_servers, removed_servers=removed_servers
-        )
 
-        self.assertDictEqual(updated_servers, {"2": "removed", "1": "added"})
+def test_unit_config_has_all_keys(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
+    config = harness.charm.cluster.unit_config(0)
 
-    def test_is_unit_turn_succeeds_scaleup(self):
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "added", "1": "added", "2": "added"}
-        )
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/0")
-        units = sorted(list(self.harness.charm.cluster.relation.units), key=lambda x: x.name)
-        self.harness.set_planned_units(1)
-        self.assertTrue(self.cluster.is_unit_turn(units[0]))
+    assert set(config.keys()) == set(
+        ["host", "server_string", "server_id", "unit_id", "unit_name", "state"]
+    )
 
-    def test_is_unit_turn_fails_scaleup(self):
-        self.harness.update_relation_data(
-            self.relation_id,
-            "zookeeper",
-            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-        )
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/0")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/3")
-        units = sorted(list(self.harness.charm.cluster.relation.units), key=lambda x: x.name)
-        self.harness.set_planned_units(4)
 
-        self.assertFalse(self.cluster.is_unit_turn(units[3]))
+def test_unit_config_server_string_format(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
+    server_string = harness.charm.cluster.unit_config(0)["server_string"]
+    split_string = re.split("=|:|;", server_string)
 
-    def test_is_unit_turn_succeeds_failover(self):
-        self.harness.update_relation_data(
-            self.relation_id,
-            "zookeeper",
-            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-        )
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/0")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/3")
-        units = sorted(list(self.harness.charm.cluster.relation.units), key=lambda x: x.name)
-        self.harness.set_planned_units(4)
+    assert len(split_string) == 7
+    assert "treebeard" in split_string
 
-        self.assertTrue(self.cluster.is_unit_turn(units[0]))
-        self.assertTrue(self.cluster.is_unit_turn(units[2]))
-        self.assertFalse(self.cluster.is_unit_turn(units[3]))
 
-    def test_is_unit_turn_fails_failover(self):
-        self.harness.update_relation_data(
-            self.relation_id,
-            "zookeeper",
-            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-        )
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/0")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/3")
-        units = sorted(list(self.harness.charm.cluster.relation.units), key=lambda x: x.name)
-        self.harness.set_planned_units(4)
+def test_get_updated_servers(harness):
+    added_servers = [
+        "server.2=gandalf.the.grey",
+    ]
+    removed_servers = [
+        "server.2=gandalf.the.grey",
+        "server.3=in.a.hole.in.the.ground.there.lived.a:hobbit",
+    ]
+    updated_servers = harness.charm.cluster._get_updated_servers(
+        added_servers=added_servers, removed_servers=removed_servers
+    )
 
-        self.assertFalse(self.cluster.is_unit_turn(units[3]))
+    assert updated_servers == {"2": "removed", "1": "added"}
 
-    def test_generate_units_scaleup_adds_all_servers(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/1", {"private-address": "gandalf"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/2", {"private-address": "gimli"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "added", "1": "added"}
-        )
 
-        new_unit_string = self.cluster.unit_config(2, state="ready", role="observer")[
-            "server_string"
-        ]
-        generated_servers = self.cluster._generate_units(unit_string=new_unit_string)
+def test_is_unit_turn_succeeds_scaleup(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "added", "1": "added", "2": "added"},
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    units = sorted(list(harness.charm.cluster.relation.units), key=lambda x: x.name)
+    harness.set_planned_units(1)
+    assert harness.charm.cluster.is_unit_turn(units[0])
 
-        self.assertIn("server.3=gimli", generated_servers)
-        self.assertEqual(len(generated_servers.splitlines()), 4)
 
-    def test_generate_units_scaleup_adds_correct_roles_for_added_units(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/1", {"private-address": "gandalf"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/2", {"private-address": "gimli"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "added", "1": "removed"}
-        )
+def test_is_unit_turn_fails_scaleup(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    units = sorted(list(harness.charm.cluster.relation.units), key=lambda x: x.name)
+    harness.set_planned_units(4)
 
-        new_unit_string = self.cluster.unit_config(2, state="ready", role="observer")[
-            "server_string"
-        ]
-        generated_servers = self.cluster._generate_units(unit_string=new_unit_string)
+    assert not harness.charm.cluster.is_unit_turn(units[3])
 
-        self.assertEqual(len(re.findall("participant", generated_servers)), 1)
-        self.assertEqual(len(re.findall("observer", generated_servers)), 1)
 
-    def test_generate_units_failover(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/1", {"private-address": "gandalf"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "removed", "1": "added", "2": "removed"}
-        )
+def test_is_unit_turn_succeeds_failover(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    units = sorted(list(harness.charm.cluster.relation.units), key=lambda x: x.name)
+    harness.set_planned_units(4)
 
-        new_unit_string = self.cluster.unit_config(0, state="ready", role="observer")[
-            "server_string"
-        ]
-        generated_servers = self.cluster._generate_units(unit_string=new_unit_string)
+    assert harness.charm.cluster.is_unit_turn(units[0])
+    assert harness.charm.cluster.is_unit_turn(units[2])
+    assert not harness.charm.cluster.is_unit_turn(units[3])
 
-        self.assertEqual(len(generated_servers.splitlines()), 3)
 
-    def test_startup_servers_raises_for_missing_data(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/2")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper", {"0": "removed", "sync_password": "Mellon"}
-        )
+def test_is_unit_turn_fails_failover(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+    )
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    units = sorted(list(harness.charm.cluster.relation.units), key=lambda x: x.name)
+    harness.set_planned_units(4)
 
-        with self.assertRaises(UnitNotFoundError):
-            self.cluster.startup_servers(unit=2)
+    assert not harness.charm.cluster.is_unit_turn(units[3])
 
-    def test_startup_servers_succeeds_init(self):
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id,
-            "zookeeper",
-            {"sync_password": "gollum", "super_password": "precious"},
-        )
-        servers = self.cluster.startup_servers(unit=0)
-        self.assertNotIn("observer", servers)
 
-    def test_startup_servers_succeeds_failover_after_init(self):
-        self.harness.add_relation_unit(self.relation_id, "zookeeper/1")
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/0", {"private-address": "treebeard"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id, "zookeeper/1", {"private-address": "gandalf"}
-        )
-        self.harness.update_relation_data(
-            self.relation_id,
-            "zookeeper",
-            {"0": "removed", "1": "added", "sync_password": "Mellon"},
-        )
+def test_generate_units_scaleup_adds_all_servers(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "added"}
+    )
 
-        generated_servers = self.cluster.startup_servers(unit=0)
+    new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
+        "server_string"
+    ]
+    generated_servers = harness.charm.cluster._generate_units(unit_string=new_unit_string)
 
-        self.assertEqual(len(re.findall("participant", generated_servers)), 1)
-        self.assertEqual(len(re.findall("observer", generated_servers)), 1)
+    assert "server.3=gimli" in generated_servers
+    assert len(generated_servers.splitlines()) == 4
+
+
+def test_generate_units_scaleup_adds_correct_roles_for_added_units(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "removed"}
+    )
+
+    new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
+        "server_string"
+    ]
+    generated_servers = harness.charm.cluster._generate_units(unit_string=new_unit_string)
+
+    assert len(re.findall("participant", generated_servers)) == 1
+    assert len(re.findall("observer", generated_servers)) == 1
+
+
+def test_generate_units_failover(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "removed", "1": "added", "2": "removed"},
+    )
+
+    new_unit_string = harness.charm.cluster.unit_config(0, state="ready", role="observer")[
+        "server_string"
+    ]
+    generated_servers = harness.charm.cluster._generate_units(unit_string=new_unit_string)
+
+    assert len(generated_servers.splitlines()) == 3
+
+
+def test_startup_servers_raises_for_missing_data(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "removed", "sync_password": "Mellon"},
+    )
+
+    with pytest.raises(UnitNotFoundError):
+        harness.charm.cluster.startup_servers(unit=2)
+
+
+def test_startup_servers_succeeds_init(harness):
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"sync_password": "gollum", "super_password": "precious"},
+    )
+    harness.set_planned_units(1)
+    servers = harness.charm.cluster.startup_servers(unit=0)
+    logger.info(harness.charm.cluster.peer_units)
+    assert "observer" not in servers
+
+
+def test_startup_servers_succeeds_failover_after_init(harness):
+    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+    )
+    harness.update_relation_data(
+        harness.charm.cluster.relation.id,
+        f"{CHARM_KEY}",
+        {"0": "removed", "1": "added", "sync_password": "Mellon"},
+    )
+
+    generated_servers = harness.charm.cluster.startup_servers(unit=0)
+
+    assert len(re.findall("participant", generated_servers)) == 1
+    assert len(re.findall("observer", generated_servers)) == 1

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -28,7 +28,7 @@ def harness():
     harness.add_relation("restart", CHARM_KEY)
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness._update_config({"init-limit": "5", "sync-limit": "2", "tick-time": "2000"})
+    harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
     harness.begin()
     return harness
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,52 +2,33 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 from pathlib import Path
 
 import pytest
 import yaml
 from charms.kafka.v0.kafka_snap import SNAP_CONFIG_PATH
-from ops.charm import CharmBase
 from ops.testing import Harness
 
-from cluster import ZooKeeperCluster
+from charm import ZooKeeperCharm
 from config import ZooKeeperConfig
-from provider import ZooKeeperProvider
-from tls import ZooKeeperTLS
+from literals import CHARM_KEY, PEER, REL_NAME
 
-METADATA = """
-    name: zookeeper
-    peers:
-        cluster:
-            interface: cluster
-        restart:
-            interface: rolling_op
-    provides:
-        zookeeper:
-            interface: zookeeper
-    requires:
-        certificates:
-            interface: tls-certifictes
-"""
+logger = logging.getLogger(__name__)
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
 
-class DummyZooKeeperCharm(CharmBase):
-    def __init__(self, *args):
-        super().__init__(*args)
-        self.cluster = ZooKeeperCluster(self)
-        self.client_relation = ZooKeeperProvider(self)
-        self.tls = ZooKeeperTLS(self)
-        self.zookeeper_config = ZooKeeperConfig(self)
-
-
-@pytest.fixture(scope="function")
+@pytest.fixture
 def harness():
-    harness = Harness(DummyZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
-    harness.begin_with_initial_hooks()
+    harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
+    harness.add_relation("restart", CHARM_KEY)
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness._update_config({"init-limit": "5", "sync-limit": "2", "tick-time": "2000"})
+    harness.begin()
     return harness
 
 
@@ -72,29 +53,29 @@ def test_kafka_opts_has_jaas(harness):
 
 
 def test_jaas_users_are_added(harness):
-    harness.add_relation("zookeeper", "application")
+    harness.add_relation(REL_NAME, "application")
     harness.update_relation_data(
-        harness.charm.client_relation.client_relations[0].id, "application", {"chroot": "app"}
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
     )
     harness.update_relation_data(
-        harness.charm.client_relation.app_relation.id, "zookeeper", {"relation-2": "password"}
+        harness.charm.provider.app_relation.id, CHARM_KEY, {"relation-2": "password"}
     )
 
     assert len(harness.charm.zookeeper_config.jaas_users) == 1
 
 
 def test_multiple_jaas_users_are_added(harness):
-    harness.add_relation("zookeeper", "application")
-    harness.add_relation("zookeeper", "application2")
+    harness.add_relation(REL_NAME, "application")
+    harness.add_relation(REL_NAME, "application2")
     harness.update_relation_data(
-        harness.charm.client_relation.client_relations[0].id, "application", {"chroot": "app"}
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
     )
     harness.update_relation_data(
-        harness.charm.client_relation.client_relations[1].id, "application2", {"chroot": "app2"}
+        harness.charm.provider.client_relations[1].id, "application2", {"chroot": "app2"}
     )
     harness.update_relation_data(
-        harness.charm.client_relation.app_relation.id,
-        "zookeeper",
+        harness.charm.provider.app_relation.id,
+        CHARM_KEY,
         {"relation-2": "password", "relation-3": "password"},
     )
 
@@ -102,7 +83,7 @@ def test_multiple_jaas_users_are_added(harness):
 
 
 def test_tls_enabled(harness):
-    harness.update_relation_data(harness.charm.tls.cluster.id, "zookeeper", {"tls": "enabled"})
+    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
     assert "ssl.clientAuth=none" in harness.charm.zookeeper_config.zookeeper_properties
 
 
@@ -111,18 +92,16 @@ def test_tls_disabled(harness):
 
 
 def test_tls_upgrading(harness):
-    harness.update_relation_data(
-        harness.charm.tls.cluster.id, "zookeeper", {"upgrading": "started"}
-    )
+    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"upgrading": "started"})
     assert "portUnification=true" in harness.charm.zookeeper_config.zookeeper_properties
 
-    harness.update_relation_data(harness.charm.tls.cluster.id, "zookeeper", {"upgrading": ""})
+    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"upgrading": ""})
     assert "portUnification=true" not in harness.charm.zookeeper_config.zookeeper_properties
 
 
 def test_tls_ssl_quorum(harness):
-    harness.update_relation_data(harness.charm.tls.cluster.id, "zookeeper", {"quorum": "ssl"})
+    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"quorum": "ssl"})
     assert "sslQuorum=true" in harness.charm.zookeeper_config.zookeeper_properties
 
-    harness.update_relation_data(harness.charm.tls.cluster.id, "zookeeper", {"quorum": "non-ssl"})
+    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"quorum": "non-ssl"})
     assert "sslQuorum=true" not in harness.charm.zookeeper_config.zookeeper_properties

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -27,7 +27,7 @@ def harness():
     harness.add_relation("restart", CHARM_KEY)
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness._update_config({"init-limit": "5", "sync-limit": "2", "tick-time": "2000"})
+    harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
     harness.begin()
     return harness
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -31,7 +31,7 @@ def harness():
     harness.add_relation(REL_NAME, "application")
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness._update_config({"init-limit": "5", "sync-limit": "2", "tick-time": "2000"})
+    harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
     harness.begin()
     return harness
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -4,368 +4,351 @@
 
 import logging
 import re
-import unittest
 from collections import namedtuple
 from pathlib import Path
 from unittest.mock import patch
 
-import ops.testing
+import pytest
 import yaml
 from ops.charm import RelationBrokenEvent
 from ops.testing import Harness
 
 from charm import ZooKeeperCharm
-
-ops.testing.SIMULATE_CAN_CONNECT = True
+from literals import CHARM_KEY, PEER, REL_NAME
 
 logger = logging.getLogger(__name__)
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
-METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
 CustomRelation = namedtuple("Relation", ["id"])
 
 
-class TestProvider(unittest.TestCase):
-    def setUp(self):
-        self.harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
-        self.addCleanup(self.harness.cleanup)
-        self.client_rel_id = self.harness.add_relation("zookeeper", "application")
-        self.peer_rel_id = self.harness.add_relation("cluster", "zookeeper")
-        self.harness.begin()
+@pytest.fixture
+def harness():
+    harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
+    harness.add_relation(REL_NAME, "application")
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness._update_config({"init-limit": "5", "sync-limit": "2", "tick-time": "2000"})
+    harness.begin()
+    return harness
 
-    @property
-    def provider(self):
-        return self.harness.charm.provider
 
-    def test_relation_config_new_relation_no_chroot(self):
-        with self.harness.hooks_disabled():
-            config = self.harness.charm.provider.relation_config(
-                relation=self.provider.client_relations[0]
-            )
-        self.assertIsNone(config)
+def test_relation_config_new_relation_no_chroot(harness):
+    with harness.hooks_disabled():
+        config = harness.charm.provider.relation_config(
+            relation=harness.charm.provider.client_relations[0]
+        )
+    assert not config
 
-    def test_relation_config_new_relation(self):
-        with self.harness.hooks_disabled():
-            self.harness.update_relation_data(
-                self.provider.client_relations[0].id, "application", {"chroot": "app"}
-            )
-            self.harness.update_relation_data(
-                self.provider.app_relation.id, "zookeeper", {"relation-0": "password"}
-            )
 
-            config = self.harness.charm.provider.relation_config(
-                relation=self.provider.client_relations[0]
-            )
-
-        self.assertEqual(
-            config,
-            {
-                "username": "relation-0",
-                "password": "password",
-                "chroot": "/app",
-                "acl": "cdrwa",
-            },
+def test_relation_config_new_relation(harness):
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, "zookeeper", {"relation-0": "password"}
         )
 
-    def test_relation_config_new_relation_defaults_to_database(self):
-        with self.harness.hooks_disabled():
-            self.harness.update_relation_data(
-                self.provider.client_relations[0].id, "application", {"database": "app"}
-            )
-            self.harness.update_relation_data(
-                self.provider.app_relation.id, "zookeeper", {"relation-0": "password"}
-            )
-
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0]
+        config = harness.charm.provider.relation_config(
+            relation=harness.charm.provider.client_relations[0]
         )
 
-        self.assertEqual(
-            config,
-            {
-                "username": "relation-0",
-                "password": "password",
-                "chroot": "/app",
-                "acl": "cdrwa",
-            },
+    assert config == {
+        "username": "relation-0",
+        "password": "password",
+        "chroot": "/app",
+        "acl": "cdrwa",
+    }
+
+
+def test_relation_config_new_relation_defaults_to_database(harness):
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"database": "app"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, "zookeeper", {"relation-0": "password"}
         )
 
-    def test_relation_config_new_relation_empty_password(self):
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
+        config = harness.charm.provider.relation_config(
+            relation=harness.charm.provider.client_relations[0]
         )
 
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0]
-        )
+        assert config == {
+            "username": "relation-0",
+            "password": "password",
+            "chroot": "/app",
+            "acl": "cdrwa",
+        }
 
-        self.assertEqual(
-            config,
-            {
-                "username": "relation-0",
-                "password": "",
-                "chroot": "/app",
-                "acl": "cdrwa",
-            },
-        )
 
-    def test_relation_config_new_relation_app_permissions(self):
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id,
-            "application",
-            {"chroot": "app", "chroot-acl": "rw"},
-        )
-
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0]
-        )
-
-        self.assertEqual(
-            config,
-            {
-                "username": "relation-0",
-                "password": "",
-                "chroot": "/app",
-                "acl": "rw",
-            },
-        )
-
-    def test_relation_config_new_relation_skips_relation_broken(self):
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id,
-            "application",
-            {"chroot": "app", "chroot-acl": "rw"},
-        )
-
-        custom_relation = CustomRelation(id=self.provider.client_relations[0].id)
-
-        config = self.harness.charm.provider.relation_config(
-            relation=self.provider.client_relations[0],
-            event=RelationBrokenEvent(handle="", relation=custom_relation),
-        )
-
-        self.assertIsNone(config)
-
-    def test_relations_config_multiple_relations(self):
-        self.harness.add_relation("zookeeper", "new_application")
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
-        )
-        self.harness.update_relation_data(
-            self.provider.client_relations[1].id, "new_application", {"chroot": "new_app"}
-        )
-
-        relations_config = self.harness.charm.provider.relations_config()
-
-        self.assertEqual(
-            relations_config,
-            {
-                "0": {
-                    "username": "relation-0",
-                    "password": "",
-                    "chroot": "/app",
-                    "acl": "cdrwa",
-                },
-                "2": {
-                    "username": "relation-2",
-                    "password": "",
-                    "chroot": "/new_app",
-                    "acl": "cdrwa",
-                },
-            },
-        )
-
-    def test_build_acls(self):
-        self.harness.add_relation("zookeeper", "new_application")
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
-        )
-        self.harness.update_relation_data(
-            self.provider.client_relations[1].id,
-            "new_application",
-            {"chroot": "new_app", "chroot-acl": "rw"},
-        )
-
-        acls = self.harness.charm.provider.build_acls()
-
-        self.assertEqual(len(acls), 2)
-        self.assertEqual(sorted(acls.keys()), ["/app", "/new_app"])
-        self.assertIsInstance(acls["/app"], list)
-
-        new_app_acl = acls["/new_app"][0]
-
-        self.assertEqual(new_app_acl.acl_list, ["READ", "WRITE"])
-        self.assertEqual(new_app_acl.id.scheme, "sasl")
-        self.assertEqual(new_app_acl.id.id, "relation-2")
-
-    def test_relations_config_values_for_key(self):
-        self.harness.add_relation("zookeeper", "new_application")
-        self.harness.update_relation_data(
-            self.provider.client_relations[0].id, "application", {"chroot": "app"}
-        )
-        self.harness.update_relation_data(
-            self.provider.client_relations[1].id,
-            "new_application",
-            {"chroot": "new_app", "chroot-acl": "rw"},
-        )
-
-        config_values = self.harness.charm.provider.relations_config_values_for_key(key="username")
-
-        self.assertEqual(config_values, {"relation-2", "relation-0"})
-
-    def test_is_child_of(self):
-        chroot = "/gandalf/the/white"
-        chroots = {"/gandalf", "/saruman"}
-
-        self.assertTrue(self.harness.charm.provider._is_child_of(path=chroot, chroots=chroots))
-
-    def test_is_child_of_not(self):
-        chroot = "/the/one/ring"
-        chroots = {"/gandalf", "/saruman"}
-
-        self.assertFalse(self.harness.charm.provider._is_child_of(path=chroot, chroots=chroots))
-
-    def test_port_updates_if_tls(self):
-        with self.harness.hooks_disabled():
-            self.harness.set_leader(True)
-            self.harness.update_relation_data(
-                self.provider.client_relations[0].id, "application", {"chroot": "app"}
-            )
-
-            # checking if ssl port and ssl flag are passed
-            self.harness.update_relation_data(
-                self.provider.app_relation.id,
-                "zookeeper/0",
-                {"private-address": "treebeard", "state": "started"},
-            )
-            self.harness.update_relation_data(
-                self.provider.app_relation.id,
-                "zookeeper",
-                {"quorum": "ssl"},
-            )
-            self.harness.charm.provider.apply_relation_data()
-
-        for relation in self.provider.client_relations:
-            uris = relation.data[self.harness.charm.app].get("uris", "")
-            ssl = relation.data[self.harness.charm.app].get("tls", "")
-
-            self.assertIn(str(self.harness.charm.cluster.secure_client_port), uris)
-            self.assertEqual(ssl, "enabled")
-
-        with self.harness.hooks_disabled():
-            # checking if normal port and non-ssl flag are passed
-            self.harness.update_relation_data(
-                self.provider.app_relation.id,
-                "zookeeper/0",
-                {"private-address": "treebeard", "state": "started", "quorum": "non-ssl"},
-            )
-            self.harness.update_relation_data(
-                self.provider.app_relation.id,
-                "zookeeper",
-                {"quorum": "non-ssl"},
-            )
-            self.harness.charm.provider.apply_relation_data()
-
-        for relation in self.provider.client_relations:
-            uris = relation.data[self.harness.charm.app].get("uris", "")
-            ssl = relation.data[self.harness.charm.app].get("tls", "")
-
-            self.assertIn(str(self.harness.charm.cluster.client_port), uris)
-            self.assertEqual(ssl, "disabled")
-
-    @patch(
-        "charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock", return_value=None
+def test_relation_config_new_relation_empty_password(harness):
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
     )
-    def test_provider_relation_data_updates_port(self, _):
-        with patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched:
-            self.harness.set_leader(True)
-            self.harness.update_relation_data(
-                self.peer_rel_id,
-                "zookeeper",
-                {"quorum": "non-ssl"},
-            )
 
-            patched.assert_called_once()
+    config = harness.charm.provider.relation_config(
+        relation=harness.charm.provider.client_relations[0]
+    )
 
-    def test_apply_relation_data(self):
-        with self.harness.hooks_disabled():
-            self.harness.set_leader(True)
-            self.harness.add_relation("zookeeper", "new_application")
-            self.harness.update_relation_data(
-                self.provider.client_relations[0].id, "application", {"chroot": "app"}
-            )
-            self.harness.update_relation_data(
-                self.provider.client_relations[1].id,
-                "new_application",
-                {"chroot": "new_app", "chroot-acl": "rw"},
-            )
-            self.harness.update_relation_data(
-                self.provider.app_relation.id,
-                "zookeeper/0",
-                {"private-address": "treebeard", "state": "started"},
-            )
-            self.harness.add_relation_unit(self.provider.app_relation.id, "zookeeper/1")
-            self.harness.update_relation_data(
-                self.provider.app_relation.id,
-                "zookeeper/1",
-                {"private-address": "shelob", "state": "ready"},
-            )
-            self.harness.add_relation_unit(self.provider.app_relation.id, "zookeeper/2")
-            self.harness.update_relation_data(
-                self.provider.app_relation.id,
-                "zookeeper/2",
-                {"private-address": "balrog", "state": "started"},
-            )
+    assert config == {
+        "username": "relation-0",
+        "password": "",
+        "chroot": "/app",
+        "acl": "cdrwa",
+    }
 
-        self.harness.charm.provider.apply_relation_data()
 
-        self.assertIsNotNone(
-            self.harness.charm.cluster.relation.data[self.harness.charm.app].get(
-                "relation-0", None
-            )
+def test_relation_config_new_relation_app_permissions(harness):
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id,
+        "application",
+        {"chroot": "app", "chroot-acl": "rw"},
+    )
+
+    config = harness.charm.provider.relation_config(
+        relation=harness.charm.provider.client_relations[0]
+    )
+
+    assert config == {
+        "username": "relation-0",
+        "password": "",
+        "chroot": "/app",
+        "acl": "rw",
+    }
+
+
+def test_relation_config_new_relation_skips_relation_broken(harness):
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id,
+        "application",
+        {"chroot": "app", "chroot-acl": "rw"},
+    )
+
+    custom_relation = CustomRelation(id=harness.charm.provider.client_relations[0].id)
+
+    config = harness.charm.provider.relation_config(
+        relation=harness.charm.provider.client_relations[0],
+        event=RelationBrokenEvent(handle="", relation=custom_relation),
+    )
+
+    assert not config
+
+
+def test_relations_config_multiple_relations(harness):
+    harness.add_relation("zookeeper", "new_application")
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+    )
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[1].id, "new_application", {"chroot": "new_app"}
+    )
+
+    relations_config = harness.charm.provider.relations_config()
+
+    assert relations_config == {
+        "0": {
+            "username": "relation-0",
+            "password": "",
+            "chroot": "/app",
+            "acl": "cdrwa",
+        },
+        "2": {
+            "username": "relation-2",
+            "password": "",
+            "chroot": "/new_app",
+            "acl": "cdrwa",
+        },
+    }
+
+
+def test_build_acls(harness):
+    harness.add_relation("zookeeper", "new_application")
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+    )
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[1].id,
+        "new_application",
+        {"chroot": "new_app", "chroot-acl": "rw"},
+    )
+
+    acls = harness.charm.provider.build_acls()
+
+    assert len(acls) == 2
+    assert sorted(acls.keys()) == ["/app", "/new_app"]
+    assert isinstance(acls["/app"], list)
+
+    new_app_acl = acls["/new_app"][0]
+
+    assert new_app_acl.acl_list == ["READ", "WRITE"]
+    assert new_app_acl.id.scheme == "sasl"
+    assert new_app_acl.id.id == "relation-2"
+
+
+def test_relations_config_values_for_key(harness):
+    harness.add_relation("zookeeper", "new_application")
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+    )
+    harness.update_relation_data(
+        harness.charm.provider.client_relations[1].id,
+        "new_application",
+        {"chroot": "new_app", "chroot-acl": "rw"},
+    )
+
+    config_values = harness.charm.provider.relations_config_values_for_key(key="username")
+
+    assert config_values == {"relation-2", "relation-0"}
+
+
+def test_is_child_of(harness):
+    chroot = "/gandalf/the/white"
+    chroots = {"/gandalf", "/saruman"}
+
+    assert harness.charm.provider._is_child_of(path=chroot, chroots=chroots)
+
+
+def test_is_child_of_not(harness):
+    chroot = "/the/one/ring"
+    chroots = {"/gandalf", "/saruman"}
+
+    assert not harness.charm.provider._is_child_of(path=chroot, chroots=chroots)
+
+
+def test_port_updates_if_tls(harness):
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
-        self.assertIsNotNone(
-            self.harness.charm.cluster.relation.data[self.harness.charm.app].get(
-                "relation-2", None
-            )
+
+        # checking if ssl port and ssl flag are passed
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            "zookeeper/0",
+            {"private-address": "treebeard", "state": "started"},
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            "zookeeper",
+            {"quorum": "ssl"},
+        )
+        harness.charm.provider.apply_relation_data()
+
+    for relation in harness.charm.provider.client_relations:
+        uris = relation.data[harness.charm.app].get("uris", "")
+        ssl = relation.data[harness.charm.app].get("tls", "")
+
+        assert str(harness.charm.cluster.secure_client_port) in uris
+        assert ssl == "enabled"
+
+    with harness.hooks_disabled():
+        # checking if normal port and non-ssl flag are passed
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            "zookeeper/0",
+            {"private-address": "treebeard", "state": "started", "quorum": "non-ssl"},
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            "zookeeper",
+            {"quorum": "non-ssl"},
+        )
+        harness.charm.provider.apply_relation_data()
+
+    for relation in harness.charm.provider.client_relations:
+        uris = relation.data[harness.charm.app].get("uris", "")
+        ssl = relation.data[harness.charm.app].get("tls", "")
+
+        assert str(harness.charm.cluster.client_port) in uris
+        assert ssl == "disabled"
+
+
+@patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock", return_value=None)
+def test_provider_relation_data_updates_port(_, harness):
+    with patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched:
+        harness.set_leader(True)
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            "zookeeper",
+            {"quorum": "non-ssl"},
         )
 
-        app_data = self.harness.charm.cluster.relation.data[self.harness.charm.app]
-        passwords = []
-        usernames = []
-        for relation in self.provider.client_relations:
-            # checking existence of all necessary keys
-            self.assertEqual(
-                sorted(relation.data[self.harness.charm.app].keys()),
-                sorted(["chroot", "endpoints", "password", "tls", "uris", "username"]),
-            )
+        patched.assert_called_once()
 
-            username = relation.data[self.harness.charm.app]["username"]
-            password = relation.data[self.harness.charm.app]["password"]
 
-            # checking ZK app data got updated
-            self.assertIn(username, app_data)
-            self.assertEqual(password, app_data.get(username, None))
+def test_apply_relation_data(harness):
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+        harness.add_relation("zookeeper", "new_application")
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[1].id,
+            "new_application",
+            {"chroot": "new_app", "chroot-acl": "rw"},
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            "zookeeper/0",
+            {"private-address": "treebeard", "state": "started"},
+        )
+        harness.add_relation_unit(harness.charm.cluster.relation.id, "zookeeper/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            "zookeeper/1",
+            {"private-address": "shelob", "state": "ready"},
+        )
+        harness.add_relation_unit(harness.charm.cluster.relation.id, "zookeeper/2")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            "zookeeper/2",
+            {"private-address": "balrog", "state": "started"},
+        )
 
-            # checking unique passwords and usernames for all relations
-            self.assertNotIn(username, usernames)
-            self.assertNotIn(password, passwords)
+    harness.charm.provider.apply_relation_data()
 
-            # checking multiple endpoints and uris
-            self.assertEqual(len(relation.data[self.harness.charm.app]["endpoints"].split(",")), 2)
-            self.assertEqual(len(relation.data[self.harness.charm.app]["uris"].split(",")), 2)
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-0", None)
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-2", None)
 
-            for uri in relation.data[self.harness.charm.app]["uris"].split(","):
-                # checking client_port in uri
-                self.assertTrue(re.search(r":[\d]+", uri))
+    app_data = harness.charm.cluster.relation.data[harness.charm.app]
+    passwords = []
+    usernames = []
+    for relation in harness.charm.provider.client_relations:
+        # checking existence of all necessary keys
 
-            self.assertTrue(
-                relation.data[self.harness.charm.app]["uris"].endswith(
-                    relation.data[self.harness.charm.app]["chroot"]
-                )
-            )
+        assert sorted(relation.data[harness.charm.app].keys()) == sorted(
+            ["chroot", "endpoints", "password", "tls", "uris", "username"]
+        )
 
-            passwords.append(username)
-            usernames.append(password)
+        username = relation.data[harness.charm.app]["username"]
+        password = relation.data[harness.charm.app]["password"]
+
+        # checking ZK app data got updated
+        assert username in app_data
+        assert password == app_data.get(username, None)
+
+        # checking unique passwords and usernames for all relations
+        assert username not in usernames
+        assert password not in passwords
+
+        # checking multiple endpoints and uris
+        assert len(relation.data[harness.charm.app]["endpoints"].split(",")) == 2
+        assert len(relation.data[harness.charm.app]["uris"].split(",")) == 2
+
+        for uri in relation.data[harness.charm.app]["uris"].split(","):
+            # checking client_port in uri
+            assert re.search(r":[\d]+", uri)
+
+        assert relation.data[harness.charm.app]["uris"].endswith(
+            relation.data[harness.charm.app]["chroot"]
+        )
+
+        passwords.append(username)
+        usernames.append(password)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -17,7 +17,7 @@ ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
 METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def harness():
     harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -22,7 +22,7 @@ def harness():
     harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness._update_config({"init-limit": "5", "sync-limit": "2", "tick-time": "2000"})
+    harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
     harness.begin()
     return harness
 


### PR DESCRIPTION
## Changes Made
#### `chore: use pytest for all unit-tests`
- Keeping consistency for ZK/Kafka charms, with easier test writing and deeper features made available by `pytest`

## Review Note
- There are no actual test diffs here. It's just using `pytest` instead of `unittest`