### PR TITLE
test: introduce charm.py unittest coverage

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -86,13 +86,13 @@ class ZooKeeperCharm(CharmBase):
 
     def _on_cluster_relation_changed(self, event: EventBase) -> None:
         """Generic handler for all 'something changed, update' events across all relations."""
-        # If a password rotation is needed, or in progress
-        if not self.rotate_passwords():
-            return
-
         # not all methods called
         if not self.cluster.relation:
             self.unit.status = WaitingStatus("waiting for peer relation")
+            return
+
+        # If a password rotation is needed, or in progress
+        if not self.rotate_passwords():
             return
 
         # attempt startup of server
@@ -107,7 +107,7 @@ class ZooKeeperCharm(CharmBase):
             return
 
         # check whether restart is needed for all `*_changed` events
-        self.on[self.restart.name].acquire_lock.emit()
+        self.on[f"{self.restart.name}"].acquire_lock.emit()
 
         # ensures events aren't lost during an upgrade on single units
         if self.tls.upgrading and len(self.cluster.peer_units) == 1:
@@ -316,7 +316,7 @@ class ZooKeeperCharm(CharmBase):
                 return False
 
             logger.info("Acquiring lock for password rotation")
-            self.on[self.restart.name].acquire_lock.emit()
+            self.on[f"{self.restart.name}"].acquire_lock.emit()
             return False
 
         else:

--- a/src/config.py
+++ b/src/config.py
@@ -257,7 +257,7 @@ class ZooKeeperConfig:
 
         Running ZooKeeper cluster with `reconfigEnabled` moves dynamic options
             to a dedicated dynamic file
-        These options are `dynamicConfigFile`, `clientPort` and `secureClientPort`
+        These options are `clientPort` and `secureClientPort`
 
         Args:
             properties: the properties to make static
@@ -268,9 +268,5 @@ class ZooKeeperConfig:
         return [
             prop
             for prop in properties
-            if (
-                "dynamicConfigFile" not in prop
-                and "clientPort" not in prop
-                and "secureClientPort" not in prop
-            )
+            if ("clientPort" not in prop and "secureClientPort" not in prop)
         ]

--- a/src/provider.py
+++ b/src/provider.py
@@ -286,7 +286,7 @@ class ZooKeeperProvider(Object):
                 return
 
         # All units restart after relation changed event to add new users
-        self.charm.on[self.charm.restart.name].acquire_lock.emit()
+        self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
 
     def _on_client_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Removes user from ZK app data on `client_relation_broken`.

--- a/src/tls.py
+++ b/src/tls.py
@@ -210,7 +210,7 @@ class ZooKeeperTLS(Object):
         self.set_truststore()
         self.set_p12_keystore()
 
-        self.charm.on[self.charm.restart.name].acquire_lock.emit()
+        self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
 
     def _on_certificates_broken(self, _) -> None:
         """Handler for `certificates_relation_broken` event."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -191,11 +191,10 @@ def test_restart_restarts_snap_service_if_config_changed(harness):
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
 
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as patched,
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as patched, patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
+
         harness.charm._restart(EventBase)
         patched.assert_called_once()
 
@@ -206,11 +205,9 @@ def test_restart_restarts_snap_service_if_manual(harness):
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"manual-restart": "true"})
 
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as patched,
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as patched, patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
         harness.charm._restart(EventBase)
         patched.assert_called_once()
 
@@ -220,11 +217,9 @@ def test_restart_restarts_snap_service_sleeps(harness):
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
 
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep") as patched,
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"), patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep") as patched:
         harness.charm._restart(EventBase)
         patched.assert_called_once()
 
@@ -234,11 +229,9 @@ def test_restart_restarts_snap_sets_active_status(harness):
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
 
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"), patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
         harness.charm._restart(EventBase)
         assert isinstance(harness.model.unit.status, ActiveStatus)
 
@@ -249,11 +242,9 @@ def test_restart_sets_password_rotated_on_unit(harness):
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"rotate-passwords": "true"})
 
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"), patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
         harness.charm._restart(EventBase)
         assert (
             harness.charm.cluster.relation.data[harness.charm.unit].get("password-rotated", None)
@@ -267,22 +258,18 @@ def test_restart_sets_unified(harness):
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
 
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"), patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
         harness.charm._restart(EventBase)
         assert (
             harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None) == "true"
         )
 
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": ""})
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"), patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
         harness.charm._restart(EventBase)
         assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
 
@@ -294,11 +281,9 @@ def test_restart_unsets_manual_restart(harness):
         peer_rel_id, f"{CHARM_KEY}/0", {"state": "started", "manual-restart": "true"}
     )
 
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
-        patch("charm.ZooKeeperCharm.config_changed"),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"), patch(
+        "charm.ZooKeeperCharm.config_changed"
+    ), patch("time.sleep"):
         harness.charm._restart(EventBase)
         assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
 
@@ -309,20 +294,16 @@ def test_restart_sets_quorum(harness):
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
 
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"quorum": "ssl"})
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"), patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
         harness.charm._restart(EventBase)
         assert harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None) == "ssl"
 
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"quorum": ""})
-    with (
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
-        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
-        patch("time.sleep"),
-    ):
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"), patch(
+        "charm.ZooKeeperCharm.config_changed", return_value=True
+    ), patch("time.sleep"):
         harness.charm._restart(EventBase)
         assert not harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None)
 
@@ -343,7 +324,7 @@ def test_init_server_maintenance_if_not_turn(harness):
         peer_rel_id, CHARM_KEY, {"sync-password": "mellon", "super-password": "mellon"}
     )
 
-    with (patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=False)):
+    with patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=False):
         harness.charm.init_server()
 
         assert isinstance(harness.charm.unit.status, MaintenanceStatus)
@@ -363,17 +344,17 @@ def test_init_server_calls_necessary_methods(harness):
             "quorum": "ssl",
         },
     )
-    with (
-        patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=True),
-        patch("config.ZooKeeperConfig.set_zookeeper_myid") as zookeeper_myid,
-        patch("config.ZooKeeperConfig.set_kafka_opts") as kafka_opts,
-        patch(
-            "config.ZooKeeperConfig.set_zookeeper_dynamic_properties"
-        ) as zookeeper_dynamic_properties,
-        patch("config.ZooKeeperConfig.set_zookeeper_properties") as zookeeper_properties,
-        patch("config.ZooKeeperConfig.set_jaas_config") as zookeeper_jaas_config,
-        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as restart,
-    ):
+    with patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=True), patch(
+        "config.ZooKeeperConfig.set_zookeeper_myid"
+    ) as zookeeper_myid, patch("config.ZooKeeperConfig.set_kafka_opts") as kafka_opts, patch(
+        "config.ZooKeeperConfig.set_zookeeper_dynamic_properties"
+    ) as zookeeper_dynamic_properties, patch(
+        "config.ZooKeeperConfig.set_zookeeper_properties"
+    ) as zookeeper_properties, patch(
+        "config.ZooKeeperConfig.set_jaas_config"
+    ) as zookeeper_jaas_config, patch(
+        "charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"
+    ) as restart:
         harness.charm.init_server()
 
         zookeeper_myid.assert_called_once()
@@ -398,24 +379,26 @@ def test_config_changed_updates_properties_and_jaas(harness):
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
-    with (
-        patch("config.ZooKeeperConfig.build_static_properties", return_value=["gandalf=white"]),
-        patch("config.ZooKeeperConfig.static_properties", return_value="gandalf=grey"),
-        patch("config.ZooKeeperConfig.jaas_config", return_value=""),
-        patch("config.ZooKeeperConfig.set_zookeeper_properties") as set_props,
-        patch("config.ZooKeeperConfig.set_jaas_config") as set_jaas,
-    ):
+    with patch(
+        "config.ZooKeeperConfig.build_static_properties", return_value=["gandalf=white"]
+    ), patch("config.ZooKeeperConfig.static_properties", return_value="gandalf=grey"), patch(
+        "config.ZooKeeperConfig.jaas_config", return_value=""
+    ), patch(
+        "config.ZooKeeperConfig.set_zookeeper_properties"
+    ) as set_props, patch(
+        "config.ZooKeeperConfig.set_jaas_config"
+    ) as set_jaas:
         harness.charm.config_changed()
         set_props.assert_called_once()
         set_jaas.assert_not_called()
 
-    with (
-        patch("config.ZooKeeperConfig.jaas_config", return_value="gandalf=white"),
-        patch("charm.safe_get_file", return_value=["gandalf=grey"]),
-        patch("config.ZooKeeperConfig.build_static_properties", return_value=[]),
-        patch("config.ZooKeeperConfig.set_zookeeper_properties") as set_props,
-        patch("config.ZooKeeperConfig.set_jaas_config") as set_jaas,
-    ):
+    with patch("config.ZooKeeperConfig.jaas_config", return_value="gandalf=white"), patch(
+        "charm.safe_get_file", return_value=["gandalf=grey"]
+    ), patch("config.ZooKeeperConfig.build_static_properties", return_value=[]), patch(
+        "config.ZooKeeperConfig.set_zookeeper_properties"
+    ) as set_props, patch(
+        "config.ZooKeeperConfig.set_jaas_config"
+    ) as set_jaas:
         harness.charm.config_changed()
         set_props.assert_not_called()
         set_jaas.assert_called_once()
@@ -435,10 +418,9 @@ def test_update_quorum_skips_relation_departed(harness):
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
-    with (
-        patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader,
-        patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,
-    ):
+    with patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader, patch(
+        "cluster.ZooKeeperCluster.update_cluster"
+    ) as patched_update_cluster:
         harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
         patched_init_leader.assert_not_called()
         patched_update_cluster.assert_not_called()
@@ -450,7 +432,7 @@ def test_update_quorum_updates_cluster_for_relation_departed(harness):
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
     harness.set_leader(True)
 
-    with (patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,):
+    with patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster:
         harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
         patched_update_cluster.assert_called()
 
@@ -460,14 +442,14 @@ def test_update_quorum_updates_cluster_for_leader_elected(harness):
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
 
-    with (patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,):
+    with patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster:
         harness.set_leader(True)
         patched_update_cluster.assert_called()
 
 
 def test_update_quorum_adds_init_leader(harness):
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    with (patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader,):
+    with patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader:
         harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
         harness.set_leader(True)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ops.framework import EventBase
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.testing import Harness
+
+from charm import ZooKeeperCharm
+from literals import CHARM_KEY, PEER
+
+logger = logging.getLogger(__name__)
+
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
+    harness.add_relation("restart", CHARM_KEY)
+    harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
+    harness.begin()
+    return harness
+
+
+def test_install_fails_create_passwords_until_peer_relation(harness):
+    with harness.hooks_disabled():
+        harness.set_leader(True)
+
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.install"):
+        harness.charm.on.install.emit()
+
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_leader(True)
+
+    assert not harness.charm.cluster.relation.data[harness.charm.app].get("sync-password", None)
+    assert not harness.charm.cluster.relation.data[harness.charm.app].get("super-password", None)
+
+
+def test_install_fails_creates_passwords_succeeds(harness):
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_leader(True)
+
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.install"):
+        harness.charm.on.install.emit()
+
+        assert harness.charm.cluster.relation.data[harness.charm.app].get("sync-password", None)
+        assert harness.charm.cluster.relation.data[harness.charm.app].get("super-password", None)
+
+
+def test_install_blocks_snap_install_failure(harness):
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_leader(True)
+
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.install", return_value=False):
+        harness.charm.on.install.emit()
+
+        assert isinstance(harness.model.unit.status, BlockedStatus)
+
+
+def test_relation_changed_emitted_for_leader_elected(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
+        harness.set_leader(True)
+        patched.assert_called_once()
+
+
+def test_relation_changed_emitted_for_config_changed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_relation_changed_emitted_for_relation_changed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
+        harness.charm.on.cluster_relation_changed.emit(harness.charm.cluster.relation)
+        patched.assert_called_once()
+
+
+def test_relation_changed_emitted_for_relation_joined(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
+        harness.charm.on.cluster_relation_joined.emit(harness.charm.cluster.relation)
+        patched.assert_called_once()
+
+
+def test_relation_changed_emitted_for_relation_departed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
+        harness.charm.on.cluster_relation_departed.emit(harness.charm.cluster.relation)
+        patched.assert_called_once()
+
+
+def test_relation_changed_waits_until_peer_relation(harness):
+    harness.charm.on.config_changed.emit()
+    assert isinstance(harness.model.unit.status, WaitingStatus)
+
+
+def test_relation_changed_stops_if_not_rotate_passwords(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"rotate-passwords": "true"})
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"password-rotated": "true"})
+    with patch("charm.ZooKeeperCharm.update_quorum") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_not_called()
+
+
+def test_relation_changed_starts_units(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperCharm.init_server") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_relation_changed_does_not_start_units_again(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    with patch("charm.ZooKeeperCharm.init_server") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_not_called()
+
+
+def test_relation_changed_does_not_restart_on_departing(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock") as patched:
+        harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        patched.assert_not_called()
+
+
+def test_relation_changed_updates_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charm.ZooKeeperCharm.update_quorum") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_relation_changed_restarts(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_relation_changed_defers_upgrading_single_unit(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
+    with patch("ops.framework.EventBase.defer") as patched:
+        harness.charm.on.config_changed.emit()
+        patched.assert_called_once()
+
+
+def test_restart_fails_not_started(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as patched:
+        harness.charm._restart(EventBase)
+        patched.assert_not_called()
+
+
+def test_restart_restarts_snap_service_if_config_changed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as patched,
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        patched.assert_called_once()
+
+
+def test_restart_restarts_snap_service_if_manual(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"manual-restart": "true"})
+
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as patched,
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        patched.assert_called_once()
+
+
+def test_restart_restarts_snap_service_sleeps(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep") as patched,
+    ):
+        harness.charm._restart(EventBase)
+        patched.assert_called_once()
+
+
+def test_restart_restarts_snap_sets_active_status(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        assert isinstance(harness.model.unit.status, ActiveStatus)
+
+
+def test_restart_sets_password_rotated_on_unit(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"rotate-passwords": "true"})
+
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        assert (
+            harness.charm.cluster.relation.data[harness.charm.unit].get("password-rotated", None)
+            == "true"
+        )
+
+
+def test_restart_sets_unified(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        assert (
+            harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None) == "true"
+        )
+
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": ""})
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
+
+
+def test_restart_unsets_manual_restart(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(
+        peer_rel_id, f"{CHARM_KEY}/0", {"state": "started", "manual-restart": "true"}
+    )
+
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed"),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
+
+
+def test_restart_sets_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"quorum": "ssl"})
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        assert harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None) == "ssl"
+
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"quorum": ""})
+    with (
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
+        harness.charm._restart(EventBase)
+        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None)
+
+
+def test_init_server_maintenance_if_no_passwords(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    harness.charm.init_server()
+
+    assert isinstance(harness.charm.unit.status, MaintenanceStatus)
+
+
+def test_init_server_maintenance_if_not_turn(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(
+        peer_rel_id, CHARM_KEY, {"sync-password": "mellon", "super-password": "mellon"}
+    )
+
+    with (patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=False)):
+        harness.charm.init_server()
+
+        assert isinstance(harness.charm.unit.status, MaintenanceStatus)
+
+
+def test_init_server_calls_necessary_methods(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"private-address": "gimli"})
+    harness.update_relation_data(
+        peer_rel_id,
+        CHARM_KEY,
+        {
+            "sync-password": "mellon",
+            "super-password": "mellon",
+            "upgrading": "started",
+            "quorum": "ssl",
+        },
+    )
+    with (
+        patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=True),
+        patch("config.ZooKeeperConfig.set_zookeeper_myid") as zookeeper_myid,
+        patch("config.ZooKeeperConfig.set_kafka_opts") as kafka_opts,
+        patch(
+            "config.ZooKeeperConfig.set_zookeeper_dynamic_properties"
+        ) as zookeeper_dynamic_properties,
+        patch("config.ZooKeeperConfig.set_zookeeper_properties") as zookeeper_properties,
+        patch("config.ZooKeeperConfig.set_jaas_config") as zookeeper_jaas_config,
+        patch("charms.kafka.v0.kafka_snap.KafkaSnap.restart_snap_service") as restart,
+    ):
+        harness.charm.init_server()
+
+        zookeeper_myid.assert_called_once()
+        kafka_opts.assert_called_once()
+        zookeeper_dynamic_properties.assert_called_once()
+        zookeeper_properties.assert_called_once()
+        zookeeper_jaas_config.assert_called_once()
+        restart.assert_called_once()
+
+        assert harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None) == "ssl"
+        assert (
+            harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None) == "true"
+        )
+        assert (
+            harness.charm.cluster.relation.data[harness.charm.unit].get("state", None) == "started"
+        )
+
+        assert isinstance(harness.charm.unit.status, ActiveStatus)
+
+
+def test_config_changed_updates_properties_and_jaas(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with (
+        patch("config.ZooKeeperConfig.build_static_properties", return_value=["gandalf=white"]),
+        patch("config.ZooKeeperConfig.static_properties", return_value="gandalf=grey"),
+        patch("config.ZooKeeperConfig.jaas_config", return_value=""),
+        patch("config.ZooKeeperConfig.set_zookeeper_properties") as set_props,
+        patch("config.ZooKeeperConfig.set_jaas_config") as set_jaas,
+    ):
+        harness.charm.config_changed()
+        set_props.assert_called_once()
+        set_jaas.assert_not_called()
+
+    with (
+        patch("config.ZooKeeperConfig.jaas_config", return_value="gandalf=white"),
+        patch("charm.safe_get_file", return_value=["gandalf=grey"]),
+        patch("config.ZooKeeperConfig.build_static_properties", return_value=[]),
+        patch("config.ZooKeeperConfig.set_zookeeper_properties") as set_props,
+        patch("config.ZooKeeperConfig.set_jaas_config") as set_jaas,
+    ):
+        harness.charm.config_changed()
+        set_props.assert_not_called()
+        set_jaas.assert_called_once()
+
+
+def test_adding_units_updates_relation_data(harness):
+    with (patch("cluster.ZooKeeperCluster.update_cluster", return_value={"1": "added"})):
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/1", {"quorum": "ssl"})
+
+        assert harness.charm.cluster.relation.data[harness.charm.app].get("1", None) == "added"
+
+
+def test_update_quorum_skips_relation_departed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with (
+        patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader,
+        patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,
+    ):
+        harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        patched_init_leader.assert_not_called()
+        patched_update_cluster.assert_not_called()
+
+
+def test_update_quorum_updates_cluster_for_relation_departed(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+    harness.set_leader(True)
+
+    with (patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,):
+        harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        patched_update_cluster.assert_called()
+
+
+def test_update_quorum_updates_cluster_for_leader_elected(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+
+    with (patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,):
+        harness.set_leader(True)
+        patched_update_cluster.assert_called()
+
+
+def test_update_quorum_adds_init_leader(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    with (patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader,):
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_leader(True)
+
+        patched_init_leader.assert_called_once()
+
+
+def test_update_quorum_sets_non_ssl_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.set_leader(True)
+
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "non-ssl"
+
+
+def test_update_quorum_sets_ssl_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
+    harness.set_leader(True)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
+
+
+def test_update_quorum_does_not_set_ssl_quorum_until_unified(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+    with harness.hooks_disabled():
+        harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"unified": ""})
+
+    assert not harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
+
+
+def test_update_quorum_does_not_unset_upgrading_until_all_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            peer_rel_id, CHARM_KEY, {"tls": "enabled", "upgrading": "started", "quorum": "non-ssl"}
+        )
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"quorum": "non-ssl"})
+
+    assert not harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
+
+
+def test_update_quorum_unsets_upgrading_when_all_quorum(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            peer_rel_id, CHARM_KEY, {"tls": "enabled", "upgrading": "started", "quorum": "ssl"}
+        )
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/1", {"quorum": "ssl"})
+
+    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"quorum": "ssl"})
+
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
+
+
+def test_config_changed_applies_relation_data(harness):
+    _ = harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+
+    with patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched:
+        harness.charm.on.config_changed.emit()
+
+        patched.assert_called_once()
+
+
+def test_init_leader_is_added(harness):
+    with patch("charm.ZooKeeperCharm.config_changed", return_value=True):
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        harness.set_planned_units(2)
+
+        assert harness.charm.cluster.relation.data[harness.charm.app].get("0", None) == "added"

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -426,6 +426,7 @@ def test_all_units_quorum_fails_wrong_quorum(harness):
 
     assert not harness.charm.cluster.all_units_quorum
 
+
 def test_all_units_quorum_succeeds(harness):
     harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
     harness.update_relation_data(harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"})

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -294,7 +294,6 @@ def test_startup_servers_succeeds_init(harness):
     )
     harness.set_planned_units(1)
     servers = harness.charm.cluster.startup_servers(unit=0)
-    logger.info(harness.charm.cluster.peer_units)
     assert "observer" not in servers
 
 
@@ -326,7 +325,7 @@ def test_all_units_related(harness):
 
 
 def test_lowest_unit_id_none_if_not_all_related(harness):
-    assert harness.charm.cluster.lowest_unit_id == None
+    assert harness.charm.cluster.lowest_unit_id == None  # noqa: E711
 
 
 def test_lowest_unit_id(harness):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 import logging
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -29,6 +29,7 @@ CustomRelation = namedtuple("Relation", ["id"])
 def harness():
     harness = Harness(ZooKeeperCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
     harness.add_relation(REL_NAME, "application")
+    peer_rel_id = harness.add_relation("restart", CHARM_KEY)
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
     harness._update_config({"init-limit": 5, "sync-limit": 2, "tick-time": 2000})
@@ -157,8 +158,8 @@ def test_relations_config_multiple_relations(harness):
             "chroot": "/app",
             "acl": "cdrwa",
         },
-        "2": {
-            "username": "relation-2",
+        "3": {
+            "username": "relation-3",
             "password": "",
             "chroot": "/new_app",
             "acl": "cdrwa",
@@ -187,7 +188,7 @@ def test_build_acls(harness):
 
     assert new_app_acl.acl_list == ["READ", "WRITE"]
     assert new_app_acl.id.scheme == "sasl"
-    assert new_app_acl.id.id == "relation-2"
+    assert new_app_acl.id.id == "relation-3"
 
 
 def test_relations_config_values_for_key(harness):
@@ -203,7 +204,7 @@ def test_relations_config_values_for_key(harness):
 
     config_values = harness.charm.provider.relations_config_values_for_key(key="username")
 
-    assert config_values == {"relation-2", "relation-0"}
+    assert config_values == {"relation-3", "relation-0"}
 
 
 def test_is_child_of(harness):
@@ -269,8 +270,7 @@ def test_port_updates_if_tls(harness):
         assert ssl == "disabled"
 
 
-@patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock", return_value=None)
-def test_provider_relation_data_updates_port(_, harness):
+def test_provider_relation_data_updates_port(harness):
     with patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched:
         harness.set_leader(True)
         harness.update_relation_data(
@@ -315,7 +315,7 @@ def test_apply_relation_data(harness):
     harness.charm.provider.apply_relation_data()
 
     assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-0", None)
-    assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-2", None)
+    assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-3", None)
 
     app_data = harness.charm.cluster.relation.data[harness.charm.app]
     passwords = []

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -50,7 +50,7 @@ def test_relation_config_new_relation(harness):
             harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, "zookeeper", {"relation-0": "password"}
+            harness.charm.cluster.relation.id, REL_NAME, {"relation-0": "password"}
         )
 
         config = harness.charm.provider.relation_config(
@@ -71,7 +71,7 @@ def test_relation_config_new_relation_defaults_to_database(harness):
             harness.charm.provider.client_relations[0].id, "application", {"database": "app"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, "zookeeper", {"relation-0": "password"}
+            harness.charm.cluster.relation.id, REL_NAME, {"relation-0": "password"}
         )
 
         config = harness.charm.provider.relation_config(
@@ -140,7 +140,7 @@ def test_relation_config_new_relation_skips_relation_broken(harness):
 
 
 def test_relations_config_multiple_relations(harness):
-    harness.add_relation("zookeeper", "new_application")
+    harness.add_relation(REL_NAME, "new_application")
     harness.update_relation_data(
         harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
     )
@@ -167,7 +167,7 @@ def test_relations_config_multiple_relations(harness):
 
 
 def test_build_acls(harness):
-    harness.add_relation("zookeeper", "new_application")
+    harness.add_relation(REL_NAME, "new_application")
     harness.update_relation_data(
         harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
     )
@@ -191,7 +191,7 @@ def test_build_acls(harness):
 
 
 def test_relations_config_values_for_key(harness):
-    harness.add_relation("zookeeper", "new_application")
+    harness.add_relation(REL_NAME, "new_application")
     harness.update_relation_data(
         harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
     )
@@ -235,7 +235,7 @@ def test_port_updates_if_tls(harness):
         )
         harness.update_relation_data(
             harness.charm.cluster.relation.id,
-            "zookeeper",
+            REL_NAME,
             {"quorum": "ssl"},
         )
         harness.charm.provider.apply_relation_data()
@@ -256,7 +256,7 @@ def test_port_updates_if_tls(harness):
         )
         harness.update_relation_data(
             harness.charm.cluster.relation.id,
-            "zookeeper",
+            REL_NAME,
             {"quorum": "non-ssl"},
         )
         harness.charm.provider.apply_relation_data()
@@ -275,7 +275,7 @@ def test_provider_relation_data_updates_port(_, harness):
         harness.set_leader(True)
         harness.update_relation_data(
             harness.charm.cluster.relation.id,
-            "zookeeper",
+            REL_NAME,
             {"quorum": "non-ssl"},
         )
 
@@ -285,7 +285,7 @@ def test_provider_relation_data_updates_port(_, harness):
 def test_apply_relation_data(harness):
     with harness.hooks_disabled():
         harness.set_leader(True)
-        harness.add_relation("zookeeper", "new_application")
+        harness.add_relation(REL_NAME, "new_application")
         harness.update_relation_data(
             harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
         )


### PR DESCRIPTION
## Changes Made
#### `test: introduce charm.py and cluster.py unittest coverage`
- Due to active development, there were no unittests for `charm.py`. These have been added
- Added additional `cluster.py` and `tls.py` tests to add coverage for new features
#### `style: misc linting/typeerror fixes`

## Review Notes
- Please focus on `tests/unit/test_charm.py`
- There are a lot of tests, so most help would be whether any were implemented incorrectly from an `ops.testing` standpoint