### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
 
   integration-test-password-rotation-lxd:
     name: Integration tests for password-rotation (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,6 +45,9 @@ jobs:
 
   integration-test-provider-lxd:
     name: Integration tests for provider (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,6 +61,9 @@ jobs:
 
   integration-test-scaling-lxd:
     name: Integration tests for scaling (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -68,6 +77,9 @@ jobs:
 
   integration-test-tls-lxd:
     name: Integration tests for tls (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,10 @@ jobs:
 
   integration-test-password-rotation-lxd:
     name: Integration tests for password-rotation (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,6 +61,10 @@ jobs:
 
   integration-test-provider-lxd:
     name: Integration tests for provider (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -70,6 +78,10 @@ jobs:
 
   integration-test-scaling-lxd:
     name: Integration tests for scaling (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -83,6 +95,10 @@ jobs:
 
   integration-test-tls-lxd:
     name: Integration tests for tls (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.