### PR TITLE
fix: bump to 22.04, use py310

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     needs:
       - lint
       - unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
     needs:
       - lint
       - unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
     needs:
       - lint
       - unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
     needs:
       - lint
       - unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
       - lib-check
       - lint
       - unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
       - lib-check
       - lint
       - unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -84,7 +84,7 @@ jobs:
       - lib-check
       - lint
       - unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -102,7 +102,7 @@ jobs:
       - lib-check
       - lint
       - unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -124,7 +124,7 @@ jobs:
       - integration-test-provider-lxd
       - integration-test-scaling-lxd
       - integration-test-tls-lxd
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,19 +2,19 @@
 # See LICENSE file for licensing details.
 
 type: charm
-bases:
-  - build-on:
-      - name: "ubuntu"
-        channel: "20.04"
-    run-on:
-      - name: "ubuntu"
-        channel: "20.04"
 parts:
   charm:
+    charm-binary-python-packages:
+      - setuptools
     build-packages:
       - libffi-dev
       - libssl-dev
       - rustc
       - cargo
-    charm-binary-python-packages:
-      - jsonschema
+bases:
+  - build-on:
+      - name: "ubuntu"
+        channel: "22.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "22.04"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,6 +9,8 @@ description: |
   ""
 maintainers:
   - Marc Oppenheimer <marc.oppenheimer@canonical.com>
+series:
+  - jammy
 
 peers:
   cluster:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ log_cli_level = "INFO"
 # Formatting tools configuration
 [tool.black]
 line-length = 99
-target-version = ["py38"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"

--- a/tests/integration/app-charm/charmcraft.yaml
+++ b/tests/integration/app-charm/charmcraft.yaml
@@ -5,7 +5,7 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"

--- a/tests/integration/app-charm/metadata.yaml
+++ b/tests/integration/app-charm/metadata.yaml
@@ -7,6 +7,8 @@ description: |
 summary: |
   Dummy charm application meant to be used
   only for testing of the libs in this repository.
+series:
+  - jammy
 
 peers:
   cluster:


### PR DESCRIPTION
## Changes Made
##### `fix: bump to assume py310`
##### `fix: pin and enforce jammy/ubuntu-22.04`