### PR TITLE
chore: switch to 3.6/edge snap for non-root user

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         run: tox -e integration-password-rotation
 
@@ -57,7 +57,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         run: tox -e integration-provider
 
@@ -74,7 +74,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         run: tox -e integration-scaling
 
@@ -91,6 +91,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         run: tox -e integration-tls

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         run: tox -e integration-password-rotation
 
@@ -74,7 +74,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         run: tox -e integration-provider
 
@@ -92,7 +92,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         run: tox -e integration-scaling
 
@@ -110,7 +110,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         run: tox -e integration-tls
 

--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -80,7 +80,7 @@ LIBPATCH = 4
 logger = logging.getLogger(__name__)
 
 # Kazoo logs are unbearably chatty
-logging.getLogger("kazoo.client").disabled = True
+# logging.getLogger("kazoo.client").disabled = True
 
 
 class MembersSyncingError(Exception):

--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -80,7 +80,7 @@ LIBPATCH = 4
 logger = logging.getLogger(__name__)
 
 # Kazoo logs are unbearably chatty
-# logging.getLogger("kazoo.client").disabled = True
+logging.getLogger("kazoo.client").disabled = True
 
 
 class MembersSyncingError(Exception):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,3 +26,4 @@ requires:
   certificates:
     interface: tls-certificates
     limit: 1
+    optional: true

--- a/src/charm.py
+++ b/src/charm.py
@@ -82,7 +82,6 @@ class ZooKeeperCharm(CharmBase):
             return
 
         self.set_passwords()
-        self.zookeeper_config.set_log4j_properties()
 
     def _on_cluster_relation_changed(self, event: EventBase) -> None:
         """Generic handler for all 'something changed, update' events across all relations."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -82,6 +82,7 @@ class ZooKeeperCharm(CharmBase):
             return
 
         self.set_passwords()
+        self.zookeeper_config.set_log4j_properties()
 
     def _on_cluster_relation_changed(self, event: EventBase) -> None:
         """Generic handler for all 'something changed, update' events across all relations."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -168,14 +168,14 @@ class ZooKeeperCharm(CharmBase):
 
         # servers properties needs to be written to dynamic config
         servers = self.cluster.startup_servers(unit=self.unit)
-        logger.info(f"{servers=}")
+        logger.debug(f"{servers=}")
         self.zookeeper_config.set_zookeeper_dynamic_properties(servers=servers)
 
-        logger.info("setting properties and jaas")
+        logger.debug("setting properties and jaas")
         self.zookeeper_config.set_zookeeper_properties()
         self.zookeeper_config.set_jaas_config()
-        
-        logger.info(f"starting snap service")
+
+        logger.debug("starting snap service")
         self.snap.start_snap_service(snap_service="daemon")
         self.unit.status = ActiveStatus()
 
@@ -194,11 +194,11 @@ class ZooKeeperCharm(CharmBase):
     def config_changed(self):
         """Compares expected vs actual config that would require a restart to apply."""
         properties = safe_get_file(self.zookeeper_config.properties_filepath) or []
-        logger.info(f"{properties=}")
         server_properties = self.zookeeper_config.build_static_properties(properties)
         config_properties = self.zookeeper_config.static_properties
 
         properties_changed = set(server_properties) ^ set(config_properties)
+        logger.debug(f"{properties_changed=}")
 
         jaas_config = safe_get_file(self.zookeeper_config.jaas_filepath) or []
         jaas_changed = set(jaas_config) ^ set(self.zookeeper_config.jaas_config.splitlines())
@@ -214,7 +214,6 @@ class ZooKeeperCharm(CharmBase):
                     f"NEW PROPERTIES = {set(config_properties) - set(server_properties)}"
                 )
             )
-            logger.info("setting new zk properties")
             self.zookeeper_config.set_zookeeper_properties()
 
         if jaas_changed:
@@ -257,9 +256,8 @@ class ZooKeeperCharm(CharmBase):
                 (RelationDepartedEvent, LeaderElectedEvent),
             )
         ):
-            logger.info("updating cluster")
             updated_servers = self.cluster.update_cluster()
-            logger.info(f"{updated_servers=}")
+            logger.debug(f"{updated_servers=}")
             # triggers a `cluster_relation_changed` to wake up following units
             self.cluster.relation.data[self.app].update(updated_servers)
 

--- a/src/config.py
+++ b/src/config.py
@@ -247,7 +247,7 @@ class ZooKeeperConfig:
         """Writes ZooKeeper myid file to config/data."""
         safe_write_to_file(
             content=f"{int(self.charm.unit.name.split('/')[1]) + 1}",
-            path=f"{self.default_config_path}/data/myid",
+            path=f"{self.charm.snap.data_path}/myid",
         )
 
     @staticmethod

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,7 @@ from typing import List
 
 from literals import PEER, REL_NAME
 from ops.model import Relation
-from snap import SNAP_CONFIG_PATH
+from snap import SNAP_COMMON_PATH, SNAP_CONFIG_PATH
 from utils import safe_get_file, safe_write_to_file
 
 logger = logging.getLogger(__name__)
@@ -48,8 +48,10 @@ class ZooKeeperConfig:
 
     def __init__(self, charm):
         self.charm = charm
+        self.default_common_path = SNAP_COMMON_PATH
         self.default_config_path = SNAP_CONFIG_PATH
         self.properties_filepath = f"{self.default_config_path}/zoo.cfg"
+        self.log4j_properties_filepath = f"{self.default_config_path}/log4j.properites"
         self.dynamic_filepath = f"{self.default_config_path}/zookeeper-dynamic.properties"
         self.jaas_filepath = f"{self.default_config_path}/zookeeper-jaas.cfg"
         self.keystore_filepath = f"{self.default_config_path}/keystore.p12"
@@ -141,8 +143,8 @@ class ZooKeeperConfig:
             ]
             + DEFAULT_PROPERTIES.split("\n")
             + [
-                f"dataDir={self.default_config_path}/data",
-                f"dataLogDir={self.default_config_path}/log",
+                f"dataDir={self.default_common_path}/data",
+                f"dataLogDir={self.default_common_path}/log-data",
                 f"{self.current_dynamic_config_file}",
             ]
         )
@@ -248,6 +250,30 @@ class ZooKeeperConfig:
         safe_write_to_file(
             content=f"{int(self.charm.unit.name.split('/')[1]) + 1}",
             path=f"{self.default_config_path}/data/myid",
+        )
+
+    def set_log4j_properties(self) -> None:
+        """Updates default log4j.properties."""
+        default_log4j_properties = safe_get_file(self.log4j_properties_filepath) or []
+
+        updated_log4j_properties = []
+        for prop in default_log4j_properties:
+            key = prop.split("=")[0]
+            match key:
+                case "zookeeper.log.dir":
+                    new_key_value = f"zookeeper.log.dir={SNAP_COMMON_PATH}/logs"
+                case "zookeeper.root.logger":
+                    new_key_value = f"zookeeper.root.logger=INFO,CONSOLE,ROLLINGFILE,TRACEFILE"
+                case "zookeeper.log.threshold":
+                    new_key_value = "zookeeper.log.threshold=DEBUG"
+                case _:
+                    new_key_value = prop
+
+            updated_log4j_properties.append(new_key_value)
+
+        safe_write_to_file(
+            content="\n".join(updated_log4j_properties),
+            path=self.log4j_properties_filepath,
         )
 
     @staticmethod

--- a/src/literals.py
+++ b/src/literals.py
@@ -10,3 +10,4 @@ STATE = "state"
 CHARM_KEY = "zookeeper"
 CHARM_USERS = ["super", "sync"]
 CERTS_REL_NAME = "certificates"
+SNAP_COMMON_PATH = "/var/snap/zookeeper/common"

--- a/src/snap.py
+++ b/src/snap.py
@@ -7,18 +7,22 @@ import logging
 
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import snap
+from literals import SNAP_COMMON_PATH
 
 logger = logging.getLogger(__name__)
-
-SNAP_COMMON_PATH = "/var/snap/zookeeper/common"
-SNAP_CONFIG_PATH = f"{SNAP_COMMON_PATH}/conf"
 
 
 class ZooKeeperSnap:
     """Wrapper for performing common operations specific to the ZooKeeper Snap."""
 
     def __init__(self) -> None:
-        self.snap_config_path = SNAP_CONFIG_PATH
+        self.config_path = f"{SNAP_COMMON_PATH}/conf"
+        self.logs_path = f"{SNAP_COMMON_PATH}/logs"
+        self.data_path = f"{SNAP_COMMON_PATH}/log-data"
+        self.jvm_path = f"{SNAP_COMMON_PATH}/jvm"
+        self.charm_opt_path = f"{SNAP_COMMON_PATH}/opt/charm"
+        self.zookeeper_opt_path = f"{SNAP_COMMON_PATH}/opt/zookeeper"
+
         self.zookeeper = snap.SnapCache()["zookeeper"]
 
     def install(self) -> bool:

--- a/src/snap.py
+++ b/src/snap.py
@@ -10,7 +10,8 @@ from charms.operator_libs_linux.v1 import snap
 
 logger = logging.getLogger(__name__)
 
-SNAP_CONFIG_PATH = "/var/snap/zookeeper/common/"
+SNAP_COMMON_PATH = "/var/snap/zookeeper/common"
+SNAP_CONFIG_PATH = f"{SNAP_COMMON_PATH}/conf"
 
 
 class ZooKeeperSnap:

--- a/src/snap.py
+++ b/src/snap.py
@@ -33,7 +33,7 @@ class ZooKeeperSnap:
             zookeeper = cache["zookeeper"]
 
             if not zookeeper.present:
-                zookeeper.ensure(snap.SnapState.Latest, channel="3.6/stable")
+                zookeeper.ensure(snap.SnapState.Latest, channel="3.6/edge")
 
             self.zookeeper = zookeeper
             return True

--- a/src/tls.py
+++ b/src/tls.py
@@ -21,7 +21,6 @@ from literals import PEER
 from ops.charm import ActionEvent, RelationJoinedEvent
 from ops.framework import Object
 from ops.model import Relation
-from snap import SNAP_CONFIG_PATH
 from utils import generate_password, safe_write_to_file
 
 logger = logging.getLogger(__name__)
@@ -37,6 +36,7 @@ class ZooKeeperTLS(Object):
     def __init__(self, charm):
         super().__init__(charm, "tls")
         self.charm = charm
+        self.config_path = self.charm.snap.config_path
         self.certificates = TLSCertificatesRequiresV1(self.charm, "certificates")
 
         self.framework.observe(
@@ -270,7 +270,7 @@ class ZooKeeperTLS(Object):
             logger.error("Can't set private-key to unit, missing private-key in relation data")
             return
 
-        safe_write_to_file(content=self.private_key, path=f"{SNAP_CONFIG_PATH}/server.key")
+        safe_write_to_file(content=self.private_key, path=f"{self.config_path}/server.key")
 
     def set_ca(self) -> None:
         """Sets the unit ca."""
@@ -278,7 +278,7 @@ class ZooKeeperTLS(Object):
             logger.error("Can't set CA to unit, missing CA in relation data")
             return
 
-        safe_write_to_file(content=self.ca, path=f"{SNAP_CONFIG_PATH}/ca.pem")
+        safe_write_to_file(content=self.ca, path=f"{self.config_path}/ca.pem")
 
     def set_certificate(self) -> None:
         """Sets the unit signed certificate."""
@@ -286,7 +286,7 @@ class ZooKeeperTLS(Object):
             logger.error("Can't set certificate to unit, missing certificate in relation data")
             return
 
-        safe_write_to_file(content=self.certificate, path=f"{SNAP_CONFIG_PATH}/server.pem")
+        safe_write_to_file(content=self.certificate, path=f"{self.config_path}/server.pem")
 
     def set_truststore(self) -> None:
         """Adds CA to JKS truststore."""
@@ -296,7 +296,7 @@ class ZooKeeperTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.config_path,
             )
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
@@ -313,7 +313,7 @@ class ZooKeeperTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.config_path,
             )
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
@@ -327,7 +327,7 @@ class ZooKeeperTLS(Object):
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,
-                cwd=SNAP_CONFIG_PATH,
+                cwd=self.config_path,
             )
         except subprocess.CalledProcessError as e:
             logger.error(e.output)

--- a/src/tls.py
+++ b/src/tls.py
@@ -7,6 +7,7 @@
 import base64
 import logging
 import re
+import shutil
 import socket
 import subprocess
 from typing import Dict, List, Optional
@@ -298,6 +299,7 @@ class ZooKeeperTLS(Object):
                 universal_newlines=True,
                 cwd=self.config_path,
             )
+            shutil.chown(f"{self.config_path}/truststore.jks", user="snap_daemon", group="root")
         except subprocess.CalledProcessError as e:
             # in case this reruns and fails
             if "already exists" in e.output:
@@ -315,6 +317,7 @@ class ZooKeeperTLS(Object):
                 universal_newlines=True,
                 cwd=self.config_path,
             )
+            shutil.chown(f"{self.config_path}/keystore.p12", user="snap_daemon", group="root")
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
             raise e

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,7 +23,6 @@ def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
     with open(path, mode) as f:
         f.write(content)
 
-    os.chmod(path, 0o774)
     shutil.chown(path, user="snap_daemon", group="root")
 
     return

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,7 +23,7 @@ def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
     with open(path, mode) as f:
         f.write(content)
 
-    os.chmod(path, 0o770)
+    os.chmod(path, 0o774)
     shutil.chown(path, user="snap_daemon", group="root")
 
     return

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,7 @@
 
 import os
 import secrets
+import shutil
 import string
 from typing import List, Optional
 
@@ -22,8 +23,8 @@ def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
     with open(path, mode) as f:
         f.write(content)
 
-    # os.chmod(path, 0o770)
-    # shutil.chown(path, user="snap_daemon", group="root")
+    os.chmod(path, 0o770)
+    shutil.chown(path, user="snap_daemon", group="root")
 
     return
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,7 +6,6 @@
 
 import os
 import secrets
-import shutil
 import string
 from typing import List, Optional
 
@@ -23,8 +22,8 @@ def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
     with open(path, mode) as f:
         f.write(content)
 
-    os.chmod(path, 0o770)
-    shutil.chown(path, user="snap_daemon", group="root")
+    # os.chmod(path, 0o770)
+    # shutil.chown(path, user="snap_daemon", group="root")
 
     return
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,7 @@
 
 import os
 import secrets
+import shutil
 import string
 from typing import List, Optional
 
@@ -21,6 +22,9 @@ def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, mode) as f:
         f.write(content)
+
+    os.chmod(path, 0o770)
+    shutil.chown(path, user="snap_daemon", group="root")
 
     return
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -147,7 +147,7 @@ async def ping_servers(ops_test: OpsTest) -> bool:
 
 def check_jaas_config(model_full_name: str, unit: str):
     config = check_output(
-        f"JUJU_MODEL={model_full_name} juju exec cat /var/snap/zookeeper/common/zookeeper-jaas.cfg --unit {unit}",
+        f"JUJU_MODEL={model_full_name} juju exec cat /var/snap/zookeeper/common/conf/zookeeper-jaas.cfg --unit {unit}",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,
@@ -187,7 +187,7 @@ def _get_show_unit_json(model_full_name: str, unit: str) -> Dict:
 
 def check_properties(model_full_name: str, unit: str):
     properties = check_output(
-        f"JUJU_MODEL={model_full_name} juju exec cat /var/snap/zookeeper/common/zoo.cfg --unit {unit}",
+        f"JUJU_MODEL={model_full_name} juju exec cat /var/snap/zookeeper/common/conf/zoo.cfg --unit {unit}",
         stderr=PIPE,
         shell=True,
         universal_newlines=True,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -353,8 +353,8 @@ def test_init_server_calls_necessary_methods(harness):
     ) as zookeeper_properties, patch(
         "config.ZooKeeperConfig.set_jaas_config"
     ) as zookeeper_jaas_config, patch(
-        "snap.ZooKeeperSnap.restart_snap_service"
-    ) as restart:
+        "snap.ZooKeeperSnap.start_snap_service"
+    ) as start:
         harness.charm.init_server()
 
         zookeeper_myid.assert_called_once()
@@ -362,7 +362,7 @@ def test_init_server_calls_necessary_methods(harness):
         zookeeper_dynamic_properties.assert_called_once()
         zookeeper_properties.assert_called_once()
         zookeeper_jaas_config.assert_called_once()
-        restart.assert_called_once()
+        start.assert_called_once()
 
         assert harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None) == "ssl"
         assert (

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,7 +11,6 @@ from charm import ZooKeeperCharm
 from config import ZooKeeperConfig
 from literals import CHARM_KEY, PEER, REL_NAME
 from ops.testing import Harness
-from snap import SNAP_CONFIG_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +47,7 @@ def test_build_static_properties_removes_necessary_rows():
 def test_server_jvmflags_has_opts(harness):
     server_jvmflags = ZooKeeperConfig(harness.charm).server_jvmflags
     assert (
-        f"-Djava.security.auth.login.config={SNAP_CONFIG_PATH}/zookeeper-jaas.cfg"
+        f"-Djava.security.auth.login.config={harness.charm.snap.config_path}/zookeeper-jaas.cfg"
         in server_jvmflags
     )
 


### PR DESCRIPTION
## Changes Made
##### `chore: switch to 3.6/edge snap for non-root user`
- Updates the snap version to `edge` channel
- Ensures files written to `$SNAP_COMMON` are owned by `snap_daemon` user