### PR TITLE
refactor: block external relation events until cluster has initialised

### DIFF
--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -74,7 +74,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -74,7 +74,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -235,10 +235,13 @@ class ZooKeeperManager:
         try:
             zk_pending_syncs = result["zk_pending_syncs"]
         except KeyError:  # missing key, no quorum, no syncing
-            logger.debug("no zk_pending_syncs key found, not syncing")
+            logger.debug("no zk_pending_syncs key found, units not syncing")
             return False
 
-        if result.get("zk_peer_state", "") == "leading - broadcast" and float(zk_pending_syncs) == 0:
+        if (
+            result.get("zk_peer_state", "") == "leading - broadcast"
+            and float(zk_pending_syncs) == 0
+        ):
             return False
 
         return True

--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -74,7 +74,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)
@@ -232,14 +232,15 @@ class ZooKeeperManager:
         ) as zk:
             result = zk.mntr
 
-        # safe cast string
         try:
-            zk_pending_syncs = float(result.get("zk_pending_syncs", ""))
-        except (ValueError, TypeError):
-            zk_pending_syncs = None
-
-        if result.get("zk_peer_state", "") == "leading - broadcast" and zk_pending_syncs == 0:
+            zk_pending_syncs = result["zk_pending_syncs"]
+        except KeyError:  # missing key, no quorum, no syncing
+            logger.debug("no zk_pending_syncs key found, not syncing")
             return False
+
+        if result.get("zk_peer_state", "") == "leading - broadcast" and float(zk_pending_syncs) == 0:
+            return False
+
         return True
 
     def add_members(self, members: Iterable[str]) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -159,10 +159,6 @@ class ZooKeeperCharm(CharmBase):
         if self.cluster.relation.data[self.app].get("rotate-passwords"):
             self.cluster.relation.data[self.unit]["password-rotated"] = "true"
 
-        if not self.tls.unit_unified(unit=self.unit) and self.tls.upgrading:
-            # if unit restarted with `upgrading` app data, must be unified
-            logger.debug(f"{self.unit.name} setting unified status")
-
         self.cluster.relation.data[self.unit].update(
             {
                 # flag to declare unit running `portUnification` during ssl<->no-ssl upgrade

--- a/src/charm.py
+++ b/src/charm.py
@@ -106,7 +106,7 @@ class ZooKeeperCharm(CharmBase):
 
         # give the leader a default quorum during cluster initialisation
         if self.unit.is_leader():
-            self.cluster.relation.data[self.app].update({"quorum": "default"})
+            self.cluster.relation.data[self.app].update({"quorum": "default - non-ssl"})
 
     def _on_cluster_relation_changed(self, event: EventBase) -> None:
         """Generic handler for all 'something changed, update' events across all relations."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,7 @@ class ZooKeeperCharm(CharmBase):
         )
 
         self.framework.observe(getattr(self.on, "install"), self._on_install)
+        self.framework.observe(getattr(self.on, "update_status"), self.update_quorum)
         self.framework.observe(
             getattr(self.on, "leader_elected"), self._on_cluster_relation_changed
         )
@@ -105,7 +106,7 @@ class ZooKeeperCharm(CharmBase):
 
         # give the leader a default quorum during cluster initialisation
         if self.unit.is_leader():
-            self.cluster.relation.data[self.app].update({"quorum": "non-ssl"})
+            self.cluster.relation.data[self.app].update({"quorum": "initializing"})
 
     def _on_cluster_relation_changed(self, event: EventBase) -> None:
         """Generic handler for all 'something changed, update' events across all relations."""
@@ -312,7 +313,7 @@ class ZooKeeperCharm(CharmBase):
                 self.cluster.relation.data[self.app].update({"quorum": "non-ssl"})
 
             if self.cluster.all_units_quorum:
-                logger.debug("all units running desired encyprtion - removing upgrading")
+                logger.debug("all units running desired encryption - removing upgrading")
                 self.cluster.relation.data[self.app].update({"upgrading": ""})
                 logger.info(f"ZooKeeper cluster switching to {self.cluster.quorum} quorum")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -106,7 +106,7 @@ class ZooKeeperCharm(CharmBase):
 
         # give the leader a default quorum during cluster initialisation
         if self.unit.is_leader():
-            self.cluster.relation.data[self.app].update({"quorum": "initializing"})
+            self.cluster.relation.data[self.app].update({"quorum": "default"})
 
     def _on_cluster_relation_changed(self, event: EventBase) -> None:
         """Generic handler for all 'something changed, update' events across all relations."""
@@ -172,8 +172,8 @@ class ZooKeeperCharm(CharmBase):
             }
         )
 
-        # relation data won't get set unless cluster is stable
-        self.provider.apply_relation_data()
+        if self.provider.ready:
+            self.provider.apply_relation_data()
 
     def init_server(self):
         """Calls startup functions for server start.
@@ -317,10 +317,7 @@ class ZooKeeperCharm(CharmBase):
                 self.cluster.relation.data[self.app].update({"upgrading": ""})
                 logger.info(f"ZooKeeper cluster switching to {self.cluster.quorum} quorum")
 
-        if self.cluster.all_units_quorum and not self.tls.upgrading:
-            logger.info(
-                "all units running desired encryption, upgrade complete - applying relation data"
-            )
+        if self.provider.ready:
             self.provider.apply_relation_data()
 
     def add_init_leader(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -103,6 +103,10 @@ class ZooKeeperCharm(CharmBase):
 
         self.set_passwords()
 
+        # give the init leader a quorum
+        if self.unit.is_leader():
+            self.cluster.relation.data[self.app].update({"quorum": "non-ssl"})
+
     def _on_cluster_relation_changed(self, event: EventBase) -> None:
         """Generic handler for all 'something changed, update' events across all relations."""
         # not all methods called
@@ -126,42 +130,46 @@ class ZooKeeperCharm(CharmBase):
             return
 
         # check whether restart is needed for all `*_changed` events
-        self.on[f"{self.restart.name}"].acquire_lock.emit()
+        if (self.config_changed() or self.tls.upgrading) and self.cluster.started:
+            self.on[f"{self.restart.name}"].acquire_lock.emit()
 
         # ensures events aren't lost during an upgrade on single units
         if self.tls.upgrading and len(self.cluster.peer_units) == 1:
             event.defer()
 
-    def _restart(self, _) -> None:
+    def _restart(self, event: EventBase) -> None:
         """Handler for emitted restart events."""
-        # 'snap restart' starts the service, so this can cause issues if ran before `init_server()`
-        if not self.cluster.started:
+        if not self.cluster.stable:
+            logger.info(f"RESTART - NOT STABLE - DEFERRING")
+            event.defer()
             return
 
-        if self.config_changed() or self.cluster.manual_restart:
-            logger.info(f"Server.{self.cluster.get_unit_id(self.unit)} restarting")
-            self.snap.restart_snap_service(snap_service="daemon")
+        logger.info(f"Server.{self.cluster.get_unit_id(self.unit)} restarting")
+        self.snap.restart_snap_service(snap_service="daemon")
 
-            # gives time for server to rejoin quorum, as command exits too fast
-            # without, other units might restart before this unit rejoins, losing quorum
-            time.sleep(5)
+        # gives time for server to rejoin quorum, as command exits too fast
+        # without, other units might restart before this unit rejoins, losing quorum
+        time.sleep(5)
 
-            self.unit.status = ActiveStatus()
+        self.unit.status = ActiveStatus()
 
         # Indicate that unit has completed restart on password rotation
         if self.cluster.relation.data[self.app].get("rotate-passwords"):
             self.cluster.relation.data[self.unit]["password-rotated"] = "true"
 
+        if not self.cluster.relation.data[self.unit].get("unified") and self.tls.upgrading:
+            logger.info("SETTING UNIFIED")
+
         self.cluster.relation.data[self.unit].update(
             {
                 # flag to declare unit running `portUnification` during ssl<->no-ssl upgrade
                 "unified": "true" if self.tls.upgrading else "",
-                # in case restart was manual
-                "manual-restart": "",
                 # flag to declare unit restarted with new quorum encryption
-                "quorum": self.cluster.quorum or "",
+                "quorum": self.cluster.quorum,
             }
         )
+
+        self.provider.apply_relation_data()
 
     def init_server(self):
         """Calls startup functions for server start.
@@ -207,11 +215,11 @@ class ZooKeeperCharm(CharmBase):
             {
                 "state": "started",
                 "unified": "true" if self.tls.upgrading else "",
-                "quorum": self.cluster.quorum or "",
+                "quorum": self.cluster.quorum,
             }
         )
 
-    def config_changed(self):
+    def config_changed(self) -> bool:
         """Compares expected vs actual config that would require a restart to apply."""
         properties = safe_get_file(self.zookeeper_config.properties_filepath) or []
         server_properties = self.zookeeper_config.build_static_properties(properties)
@@ -282,25 +290,30 @@ class ZooKeeperCharm(CharmBase):
             self.cluster.relation.data[self.app].update(updated_servers)
 
         # default startup without ssl relation
-        if not self.cluster.stale_quorum and not self.tls.enabled and not self.tls.upgrading:
-            if not self.cluster.quorum:  # avoids multiple loglines
-                logger.info("ZooKeeper cluster running with non-SSL quorum")
-
-            self.cluster.relation.data[self.app].update({"quorum": "non-ssl"})
+        logger.info("UPDATE QUORUM - CHECKING STABLE")
+        if not self.cluster.stable:
+            return
 
         # declare upgrade complete only when all peer units have started
         # triggers `cluster_relation_changed` to rolling-restart without `portUnification`
         if self.tls.all_units_unified:
+            logger.info("ALL UNITS UNIFIED")
             if self.tls.enabled:
+                logger.info("TLS ENABLED - SWITCHING TO SSL")
                 self.cluster.relation.data[self.app].update({"quorum": "ssl"})
             else:
+                logger.info("TLS ENABLED - SWITCHING TO NON-SSL")
                 self.cluster.relation.data[self.app].update({"quorum": "non-ssl"})
 
             if self.cluster.all_units_quorum:
+                logger.info("ALL UNITS QUORUM - REMOVING UPGRADE")
                 self.cluster.relation.data[self.app].update({"upgrading": ""})
-                logger.debug(f"ZooKeeper cluster switching to {self.cluster.quorum} quorum")
+                logger.info(f"ZooKeeper cluster switching to {self.cluster.quorum} quorum")
+                logger.info("UPDATE QUORUM - NEW QUORUM - UPDATING RELATION DATA")
 
-        self.provider.apply_relation_data()
+        if self.cluster.all_units_quorum and not self.tls.upgrading:
+            logger.info("ALL UNITS QUORUM AND NOT UPGRADING - APPLYING")
+            self.provider.apply_relation_data()
 
     def add_init_leader(self) -> None:
         """Adds the first leader server to the relation data for other units to ack."""

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -464,7 +464,7 @@ class ZooKeeperCluster:
         Returns:
             String of either `ssl` or `non-ssl`. Defaults `non-ssl`.
         """
-        return self.relation.data[self.charm.app].get("quorum", "non-ssl")
+        return self.relation.data[self.charm.app].get("quorum", "default - non-ssl")
 
     @property
     def all_units_quorum(self) -> bool:
@@ -474,20 +474,19 @@ class ZooKeeperCluster:
             True if all units are running the quorum encryption in app data.
                 Otherwise False.
         """
-        # FIXME: something might be going wrong here
         unit_quorums = set()
         for unit in self.peer_units:
             unit_quorum = self.relation.data[unit].get("quorum", None)
             if unit_quorum != self.quorum:
-                logger.info(
-                    f"NOT ALL UNITS QUORUM - {unit.name} has {unit_quorum}, cluster has {self.quorum}"
+                logger.debug(
+                    f"not all units quorum - {unit.name} has {unit_quorum}, cluster has {self.quorum}"
                 )
                 return False
 
             unit_quorums.add(unit_quorum)
 
         if len(unit_quorums) != 1:
-            logger.info(f"NOT ALL UNITS QUORUM - {unit_quorums=}")
+            logger.debug(f"not all unts quorum - {unit_quorums=}")
 
         return len(unit_quorums) == 1
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -479,13 +479,15 @@ class ZooKeeperCluster:
         for unit in self.peer_units:
             unit_quorum = self.relation.data[unit].get("quorum", None)
             if unit_quorum != self.quorum:
-                logger.info(f'NOT ALL UNITS QUORUM - {unit.name} has {unit_quorum}, cluster has {self.quorum}')
+                logger.info(
+                    f"NOT ALL UNITS QUORUM - {unit.name} has {unit_quorum}, cluster has {self.quorum}"
+                )
                 return False
 
             unit_quorums.add(unit_quorum)
 
         if len(unit_quorums) != 1:
-            logger.info(f'NOT ALL UNITS QUORUM - {unit_quorums=}')
+            logger.info(f"NOT ALL UNITS QUORUM - {unit_quorums=}")
 
         return len(unit_quorums) == 1
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -474,13 +474,18 @@ class ZooKeeperCluster:
             True if all units are running the quorum encryption in app data.
                 Otherwise False.
         """
+        # FIXME: something might be going wrong here
         unit_quorums = set()
         for unit in self.peer_units:
             unit_quorum = self.relation.data[unit].get("quorum", None)
             if unit_quorum != self.quorum:
+                logger.info(f'NOT ALL UNITS QUORUM - {unit.name} has {unit_quorum}, cluster has {self.quorum}')
                 return False
 
             unit_quorums.add(unit_quorum)
+
+        if len(unit_quorums) != 1:
+            logger.info(f'NOT ALL UNITS QUORUM - {unit_quorums=}')
 
         return len(unit_quorums) == 1
 

--- a/src/provider.py
+++ b/src/provider.py
@@ -233,7 +233,7 @@ class ZooKeeperProvider(Object):
         for relation_id, config in relations_config.items():
             # avoid adding relation data for related apps without acls
             if config["acls-added"] != "true":
-                logger.info(f"{relation_id} has yet to add acls")
+                logger.debug(f"{relation_id} has yet to add acls")
                 continue
 
             hosts = self.charm.cluster.active_hosts
@@ -255,7 +255,7 @@ class ZooKeeperProvider(Object):
                 ",".join([f"{host}:{port}" for host in hosts]) + config["chroot"]
             )
 
-            logger.info(f"setting relation data - {relation_data.items()}")
+            logger.debug(f"setting relation data - {relation_data.items()}")
             self.charm.model.get_relation(REL_NAME, int(relation_id)).data[self.charm.app].update(
                 relation_data
             )
@@ -273,7 +273,7 @@ class ZooKeeperProvider(Object):
 
         # ACLs created before passwords set to avoid restarting before successful adding
         try:
-            logger.info(f"adding acls for {getattr(event.app, 'name', None)}")
+            logger.debug(f"adding acls for {getattr(event.app, 'name', None)}")
             self.update_acls(event=event)
         except (
             MembersSyncingError,
@@ -289,7 +289,7 @@ class ZooKeeperProvider(Object):
         # new users won't have a password yet, one will be generated here
         relation_config = self.relation_config(relation=event.relation)
         if relation_config and relation_config.get("acls-added"):
-            logger.info(f"updating passwords for {getattr(event.app, 'name', None)}")
+            logger.debug(f"updating passwords for {getattr(event.app, 'name', None)}")
             # triggers relation_changed for other units to restart
             self.app_relation.data[self.charm.app].update(
                 {relation_config["username"]: relation_config["password"]}
@@ -324,19 +324,19 @@ class ZooKeeperProvider(Object):
             True if ready. Otherwise False
         """
         if not self.charm.cluster.all_units_quorum:
-            logger.info("provider not ready - not all units quorum")
+            logger.debug("provider not ready - not all units quorum")
             return False
 
         if self.charm.tls.upgrading:
-            logger.info("provider not ready - upgrading")
+            logger.debug("provider not ready - upgrading")
             return False
 
         if self.charm.tls.all_units_unified:
-            logger.info("provider not ready - all units unified")
+            logger.debug("provider not ready - all units unified")
             return False
 
         if not self.charm.cluster.stable:
-            logger.info("provider not ready - cluster not stable")
+            logger.debug("provider not ready - cluster not stable")
             return False
 
         return True

--- a/src/provider.py
+++ b/src/provider.py
@@ -99,7 +99,7 @@ class ZooKeeperProvider(Object):
             "password": password,
             "chroot": chroot,
             "acl": acl,
-            "acls-added": str(acls_added),
+            "acls-added": acls_added,
         }
 
     def relations_config(self, event: Optional[EventBase] = None) -> Dict[str, Dict[str, str]]:

--- a/src/provider.py
+++ b/src/provider.py
@@ -269,7 +269,6 @@ class ZooKeeperProvider(Object):
         Future `client_relation_changed` events called on non-leader units checks passwords before
             restarting.
         """
-
         # avoids failure from early relation
         if not self.charm.cluster.stable:
             logger.debug("client relation joined - cluster not stable - deferring")

--- a/src/tls.py
+++ b/src/tls.py
@@ -160,9 +160,9 @@ class ZooKeeperTLS(Object):
         """Handler for `certificates_relation_created` event."""
         if not self.charm.unit.is_leader():
             return
-        
+
         if not self.charm.cluster.stable:
-            logger.info("CERTIFICATES CREATED - NOT STABLE - DEFERRING")
+            logger.debug("certificates relation created - quroum not stable - deferring")
             event.defer()
             return
 
@@ -174,7 +174,9 @@ class ZooKeeperTLS(Object):
     def _on_certificates_joined(self, event: RelationJoinedEvent) -> None:
         """Handler for `certificates_relation_joined` event."""
         if not self.enabled:
-            logger.info("CERTIFICATES JOINED - NOT UPGRADING, NOT STABLE - DEFER")
+            logger.info(
+                "certificates relation joined - tls not enabled and not upgrading - deferring"
+            )
             event.defer()
             return
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -187,7 +187,7 @@ class ZooKeeperTLS(Object):
     def _on_certificates_joined(self, event: RelationJoinedEvent) -> None:
         """Handler for `certificates_relation_joined` event."""
         if not self.enabled:
-            logger.info(
+            logger.debug(
                 "certificates relation joined - tls not enabled and not upgrading - deferring"
             )
             event.defer()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -729,3 +729,10 @@ def test_init_leader_is_added(harness):
         harness.set_planned_units(2)
 
         assert harness.charm.cluster.relation.data[harness.charm.app].get("0", None) == "added"
+
+
+def test_update_status_updates_quorum(harness):
+    with patch("charm.ZooKeeperCharm.update_quorum") as patched:
+        harness.charm.on.update_status.emit()
+
+    patched.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,7 +4,7 @@
 
 import logging
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 import yaml
@@ -72,40 +72,50 @@ def test_install_blocks_snap_install_failure(harness):
 
 
 def test_relation_changed_emitted_for_leader_elected(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with (patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched,):
         harness.set_leader(True)
         patched.assert_called_once()
 
 
 def test_relation_changed_emitted_for_config_changed(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
     with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
         harness.charm.on.config_changed.emit()
         patched.assert_called_once()
 
 
 def test_relation_changed_emitted_for_relation_changed(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
     with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
         harness.charm.on.cluster_relation_changed.emit(harness.charm.cluster.relation)
         patched.assert_called_once()
 
 
 def test_relation_changed_emitted_for_relation_joined(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
     with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
         harness.charm.on.cluster_relation_joined.emit(harness.charm.cluster.relation)
         patched.assert_called_once()
 
 
 def test_relation_changed_emitted_for_relation_departed(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
     with patch("charm.ZooKeeperCharm._on_cluster_relation_changed") as patched:
         harness.charm.on.cluster_relation_departed.emit(harness.charm.cluster.relation)
         patched.assert_called_once()
@@ -117,8 +127,10 @@ def test_relation_changed_waits_until_peer_relation(harness):
 
 
 def test_relation_changed_stops_if_not_rotate_passwords(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
     harness.update_relation_data(peer_rel_id, CHARM_KEY, {"rotate-passwords": "true"})
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"password-rotated": "true"})
     with patch("charm.ZooKeeperCharm.update_quorum") as patched:
@@ -127,188 +139,234 @@ def test_relation_changed_stops_if_not_rotate_passwords(harness):
 
 
 def test_relation_changed_starts_units(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    with patch("charm.ZooKeeperCharm.init_server") as patched:
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with (
+        patch("charm.ZooKeeperCharm.init_server") as patched,
+        patch("charm.ZooKeeperCharm.config_changed"),
+    ):
         harness.charm.on.config_changed.emit()
         patched.assert_called_once()
 
 
 def test_relation_changed_does_not_start_units_again(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
     harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
-    with patch("charm.ZooKeeperCharm.init_server") as patched:
+    with (
+        patch("charm.ZooKeeperCharm.init_server") as patched,
+        patch("charm.ZooKeeperCharm.config_changed"),
+    ):
         harness.charm.on.config_changed.emit()
         patched.assert_not_called()
 
 
 def test_relation_changed_does_not_restart_on_departing(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
     with patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock") as patched:
         harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
         patched.assert_not_called()
 
 
 def test_relation_changed_updates_quorum(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    with patch("charm.ZooKeeperCharm.update_quorum") as patched:
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with (
+        patch("charm.ZooKeeperCharm.update_quorum") as patched,
+        patch("charm.ZooKeeperCharm.config_changed"),
+    ):
         harness.charm.on.config_changed.emit()
         patched.assert_called_once()
 
 
 def test_relation_changed_restarts(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    with patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock") as patched:
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    with (
+        patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock") as patched,
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
         harness.charm.on.config_changed.emit()
         patched.assert_called_once()
 
 
 def test_relation_changed_defers_upgrading_single_unit(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
-    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
-    with patch("ops.framework.EventBase.defer") as patched:
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+        harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
+
+    with (
+        patch("ops.framework.EventBase.defer") as patched,
+        patch("charm.ZooKeeperCharm.config_changed"),
+    ):
         harness.charm.on.config_changed.emit()
         patched.assert_called_once()
 
 
+def test_restart_fails_not_related(harness):
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with (
+        patch("snap.ZooKeeperSnap.restart_snap_service") as patched,
+        patch("ops.framework.EventBase.defer"),
+    ):
+        harness.charm._restart(EventBase)
+        patched.assert_not_called()
+
+
 def test_restart_fails_not_started(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    with patch("snap.ZooKeeperSnap.restart_snap_service") as patched:
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_planned_units(1)
+
+    with (
+        patch("snap.ZooKeeperSnap.restart_snap_service") as patched,
+        patch("ops.framework.EventBase.defer"),
+    ):
+        harness.charm._restart(EventBase)
+        patched.assert_not_called()
+
+
+def test_restart_fails_not_added(harness):
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_planned_units(1)
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+
+    with (
+        patch("snap.ZooKeeperSnap.restart_snap_service") as patched,
+        patch("ops.framework.EventBase.defer"),
+    ):
         harness.charm._restart(EventBase)
         patched.assert_not_called()
 
 
 def test_restart_restarts_snap_service_if_config_changed(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_planned_units(1)
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}", {"0": "added"})
 
-    with patch("snap.ZooKeeperSnap.restart_snap_service") as patched, patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep"):
-        harness.charm._restart(EventBase)
-        patched.assert_called_once()
-
-
-def test_restart_restarts_snap_service_if_manual(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
-    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"manual-restart": "true"})
-
-    with patch("snap.ZooKeeperSnap.restart_snap_service") as patched, patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep"):
+    with (
+        patch("snap.ZooKeeperSnap.restart_snap_service") as patched,
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+        patch("ops.framework.EventBase.defer"),
+    ):
         harness.charm._restart(EventBase)
         patched.assert_called_once()
 
 
 def test_restart_restarts_snap_service_sleeps(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_planned_units(1)
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}", {"0": "added"})
 
-    with patch("snap.ZooKeeperSnap.restart_snap_service"), patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep") as patched:
+    with (
+        patch("snap.ZooKeeperSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep") as patched,
+    ):
         harness.charm._restart(EventBase)
         patched.assert_called_once()
 
 
 def test_restart_restarts_snap_sets_active_status(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_planned_units(1)
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}", {"0": "added"})
 
-    with patch("snap.ZooKeeperSnap.restart_snap_service"), patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep"):
+    with (
+        patch("snap.ZooKeeperSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
         harness.charm._restart(EventBase)
         assert isinstance(harness.model.unit.status, ActiveStatus)
 
 
 def test_restart_sets_password_rotated_on_unit(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
-    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"rotate-passwords": "true"})
-
-    with patch("snap.ZooKeeperSnap.restart_snap_service"), patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep"):
-        harness.charm._restart(EventBase)
-        assert (
-            harness.charm.cluster.relation.data[harness.charm.unit].get("password-rotated", None)
-            == "true"
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.set_planned_units(1)
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+        harness.update_relation_data(
+            peer_rel_id, f"{CHARM_KEY}", {"0": "added", "rotate-passwords": "true"}
         )
+
+    with (
+        patch("snap.ZooKeeperSnap.restart_snap_service"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
+        harness.charm._restart(EventBase)
+
+    assert (
+        harness.charm.cluster.relation.data[harness.charm.unit].get("password-rotated", None)
+        == "true"
+    )
 
 
 def test_restart_sets_unified(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
+        harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
 
-    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": "started"})
-    with patch("snap.ZooKeeperSnap.restart_snap_service"), patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep"):
+    with (
+        patch("snap.ZooKeeperSnap.restart_snap_service"),
+        patch("cluster.ZooKeeperCluster.stable", return_value=True),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("time.sleep"),
+    ):
         harness.charm._restart(EventBase)
         assert (
             harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None) == "true"
         )
 
-    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": ""})
-    with patch("snap.ZooKeeperSnap.restart_snap_service"), patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep"):
-        harness.charm._restart(EventBase)
-        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
-
-
-def test_restart_unsets_manual_restart(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(
-        peer_rel_id, f"{CHARM_KEY}/0", {"state": "started", "manual-restart": "true"}
-    )
-
-    with patch("snap.ZooKeeperSnap.restart_snap_service"), patch(
-        "charm.ZooKeeperCharm.config_changed"
-    ), patch("time.sleep"):
-        harness.charm._restart(EventBase)
-        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
-
-
-def test_restart_sets_quorum(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"state": "started"})
-
-    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"quorum": "ssl"})
-    with patch("snap.ZooKeeperSnap.restart_snap_service"), patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep"):
-        harness.charm._restart(EventBase)
-        assert harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None) == "ssl"
-
-    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"quorum": ""})
-    with patch("snap.ZooKeeperSnap.restart_snap_service"), patch(
-        "charm.ZooKeeperCharm.config_changed", return_value=True
-    ), patch("time.sleep"):
-        harness.charm._restart(EventBase)
-        assert not harness.charm.cluster.relation.data[harness.charm.unit].get("quorum", None)
+        harness.update_relation_data(peer_rel_id, CHARM_KEY, {"upgrading": ""})
+        with (
+            patch("snap.ZooKeeperSnap.restart_snap_service"),
+            patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+            patch("time.sleep"),
+        ):
+            harness.charm._restart(EventBase)
+            assert not harness.charm.cluster.relation.data[harness.charm.unit].get("unified", None)
 
 
 def test_init_server_maintenance_if_no_passwords(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
     harness.charm.init_server()
 
@@ -316,11 +374,12 @@ def test_init_server_maintenance_if_no_passwords(harness):
 
 
 def test_init_server_maintenance_if_not_turn(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(
-        peer_rel_id, CHARM_KEY, {"sync-password": "mellon", "super-password": "mellon"}
-    )
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.update_relation_data(
+            peer_rel_id, CHARM_KEY, {"sync-password": "mellon", "super-password": "mellon"}
+        )
 
     with patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=False):
         harness.charm.init_server()
@@ -329,32 +388,31 @@ def test_init_server_maintenance_if_not_turn(harness):
 
 
 def test_init_server_calls_necessary_methods(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"private-address": "gimli"})
-    harness.update_relation_data(
-        peer_rel_id,
-        CHARM_KEY,
-        {
-            "sync-password": "mellon",
-            "super-password": "mellon",
-            "upgrading": "started",
-            "quorum": "ssl",
-        },
-    )
-    with patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=True), patch(
-        "config.ZooKeeperConfig.set_zookeeper_myid"
-    ) as zookeeper_myid, patch(
-        "config.ZooKeeperConfig.set_server_jvmflags"
-    ) as server_jvmflags, patch(
-        "config.ZooKeeperConfig.set_zookeeper_dynamic_properties"
-    ) as zookeeper_dynamic_properties, patch(
-        "config.ZooKeeperConfig.set_zookeeper_properties"
-    ) as zookeeper_properties, patch(
-        "config.ZooKeeperConfig.set_jaas_config"
-    ) as zookeeper_jaas_config, patch(
-        "snap.ZooKeeperSnap.start_snap_service"
-    ) as start:
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.update_relation_data(peer_rel_id, f"{CHARM_KEY}/0", {"private-address": "gimli"})
+        harness.update_relation_data(
+            peer_rel_id,
+            CHARM_KEY,
+            {
+                "sync-password": "mellon",
+                "super-password": "mellon",
+                "upgrading": "started",
+                "quorum": "ssl",
+            },
+        )
+    with (
+        patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=True),
+        patch("config.ZooKeeperConfig.set_zookeeper_myid") as zookeeper_myid,
+        patch("config.ZooKeeperConfig.set_server_jvmflags") as server_jvmflags,
+        patch(
+            "config.ZooKeeperConfig.set_zookeeper_dynamic_properties"
+        ) as zookeeper_dynamic_properties,
+        patch("config.ZooKeeperConfig.set_zookeeper_properties") as zookeeper_properties,
+        patch("config.ZooKeeperConfig.set_jaas_config") as zookeeper_jaas_config,
+        patch("snap.ZooKeeperSnap.start_snap_service") as start,
+    ):
         harness.charm.init_server()
 
         zookeeper_myid.assert_called_once()
@@ -376,36 +434,38 @@ def test_init_server_calls_necessary_methods(harness):
 
 
 def test_config_changed_updates_properties_and_jaas(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
-    with patch(
-        "config.ZooKeeperConfig.build_static_properties", return_value=["gandalf=white"]
-    ), patch("config.ZooKeeperConfig.static_properties", return_value="gandalf=grey"), patch(
-        "config.ZooKeeperConfig.jaas_config", return_value=""
-    ), patch(
-        "config.ZooKeeperConfig.set_zookeeper_properties"
-    ) as set_props, patch(
-        "config.ZooKeeperConfig.set_jaas_config"
-    ) as set_jaas:
+    with (
+        patch("config.ZooKeeperConfig.build_static_properties", return_value=["gandalf=white"]),
+        patch("config.ZooKeeperConfig.static_properties", return_value="gandalf=grey"),
+        patch("config.ZooKeeperConfig.jaas_config", return_value=""),
+        patch("config.ZooKeeperConfig.set_zookeeper_properties") as set_props,
+        patch("config.ZooKeeperConfig.set_jaas_config") as set_jaas,
+    ):
         harness.charm.config_changed()
         set_props.assert_called_once()
         set_jaas.assert_not_called()
 
-    with patch("config.ZooKeeperConfig.jaas_config", return_value="gandalf=white"), patch(
-        "charm.safe_get_file", return_value=["gandalf=grey"]
-    ), patch("config.ZooKeeperConfig.build_static_properties", return_value=[]), patch(
-        "config.ZooKeeperConfig.set_zookeeper_properties"
-    ) as set_props, patch(
-        "config.ZooKeeperConfig.set_jaas_config"
-    ) as set_jaas:
+    with (
+        patch("config.ZooKeeperConfig.jaas_config", return_value="gandalf=white"),
+        patch("charm.safe_get_file", return_value=["gandalf=grey"]),
+        patch("config.ZooKeeperConfig.build_static_properties", return_value=[]),
+        patch("config.ZooKeeperConfig.set_zookeeper_properties") as set_props,
+        patch("config.ZooKeeperConfig.set_jaas_config") as set_jaas,
+    ):
         harness.charm.config_changed()
         set_props.assert_not_called()
         set_jaas.assert_called_once()
 
 
 def test_adding_units_updates_relation_data(harness):
-    with patch("cluster.ZooKeeperCluster.update_cluster", return_value={"1": "added"}):
+    with (
+        patch("cluster.ZooKeeperCluster.update_cluster", return_value={"1": "added"}),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
         peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
         harness.set_leader(True)
         harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
@@ -415,68 +475,66 @@ def test_adding_units_updates_relation_data(harness):
 
 
 def test_update_quorum_skips_relation_departed(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
 
-    with patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader, patch(
-        "cluster.ZooKeeperCluster.update_cluster"
-    ) as patched_update_cluster:
+    with (
+        patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader,
+        patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,
+    ):
         harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
         patched_init_leader.assert_not_called()
         patched_update_cluster.assert_not_called()
 
 
 def test_update_quorum_updates_cluster_for_relation_departed(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
-    harness.set_leader(True)
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+        harness.set_leader(True)
 
-    with patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster:
+    with (
+        patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
         harness.remove_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
         patched_update_cluster.assert_called()
 
 
 def test_update_quorum_updates_cluster_for_leader_elected(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
 
-    with patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster:
+    with (
+        patch("cluster.ZooKeeperCluster.update_cluster") as patched_update_cluster,
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
         harness.set_leader(True)
         patched_update_cluster.assert_called()
 
 
 def test_update_quorum_adds_init_leader(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    with patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader:
+    with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+
+    with (
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("charm.ZooKeeperCharm.add_init_leader") as patched_init_leader,
+    ):
         harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
         harness.set_leader(True)
 
         patched_init_leader.assert_called_once()
 
 
-def test_update_quorum_sets_non_ssl_quorum(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
-    harness.set_leader(True)
-
-    assert harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "non-ssl"
-
-
-def test_update_quorum_sets_ssl_quorum(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
-    harness.set_leader(True)
-    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
-
-    assert harness.charm.cluster.relation.data[harness.charm.app].get("quorum", None) == "ssl"
-
-
 def test_update_quorum_does_not_set_ssl_quorum_until_unified(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.set_leader(True)
     with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
         harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
         harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/1")
 
@@ -486,9 +544,9 @@ def test_update_quorum_does_not_set_ssl_quorum_until_unified(harness):
 
 
 def test_update_quorum_does_not_unset_upgrading_until_all_quorum(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.set_leader(True)
     with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
         harness.update_relation_data(
             peer_rel_id, CHARM_KEY, {"tls": "enabled", "upgrading": "started", "quorum": "non-ssl"}
         )
@@ -500,9 +558,9 @@ def test_update_quorum_does_not_unset_upgrading_until_all_quorum(harness):
 
 
 def test_update_quorum_unsets_upgrading_when_all_quorum(harness):
-    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
-    harness.set_leader(True)
     with harness.hooks_disabled():
+        peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
         harness.update_relation_data(
             peer_rel_id, CHARM_KEY, {"tls": "enabled", "upgrading": "started", "quorum": "ssl"}
         )
@@ -515,13 +573,151 @@ def test_update_quorum_unsets_upgrading_when_all_quorum(harness):
 
 
 def test_config_changed_applies_relation_data(harness):
-    _ = harness.add_relation(PEER, CHARM_KEY)
-    harness.set_leader(True)
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
 
-    with patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched:
+    with (
+        patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched,
+        patch("cluster.ZooKeeperCluster.stable", return_value=True),
+        patch("provider.ZooKeeperProvider.ready", return_value=True),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
         harness.charm.on.config_changed.emit()
 
         patched.assert_called_once()
+
+
+def test_config_changed_fails_apply_relation_data_not_ready(harness):
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+
+    with (
+        patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched,
+        patch("cluster.ZooKeeperCluster.stable", return_value=True),
+        patch("provider.ZooKeeperProvider.ready", new_callable=PropertyMock(return_value=False)),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
+        harness.charm.on.config_changed.emit()
+
+        patched.assert_not_called()
+
+
+def test_config_changed_fails_apply_relation_data_not_stable(harness):
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+
+    with (
+        patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched,
+        patch("cluster.ZooKeeperCluster.stable", new_callable=PropertyMock(return_value=False)),
+        patch("provider.ZooKeeperProvider.ready", return_value=True),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
+        harness.charm.on.config_changed.emit()
+
+        patched.assert_not_called()
+
+
+def test_update_quorum_updates_relation_data(harness):
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+
+    with (
+        patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched,
+        patch("cluster.ZooKeeperCluster.stable", return_value=True),
+        patch("provider.ZooKeeperProvider.ready", return_value=True),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
+        harness.charm.update_quorum(EventBase)
+
+        patched.assert_called_once()
+
+
+def test_update_quorum_fails_update_relation_data_if_not_stable(harness):
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+
+    with (
+        patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched,
+        patch("cluster.ZooKeeperCluster.stable", new_callable=PropertyMock(return_value=False)),
+        patch("provider.ZooKeeperProvider.ready", return_value=True),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
+        harness.charm.update_quorum(EventBase)
+
+        patched.assert_not_called()
+
+
+def test_update_quorum_fails_update_relation_data_if_not_ready(harness):
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+
+    with (
+        patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched,
+        patch("cluster.ZooKeeperCluster.stable", return_value=True),
+        patch("provider.ZooKeeperProvider.ready", new_callable=PropertyMock(return_value=False)),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
+        harness.charm.update_quorum(EventBase)
+
+        patched.assert_not_called()
+
+
+def test_restart_updates_relation_data(harness):
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+
+    with (
+        patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched,
+        patch("cluster.ZooKeeperCluster.stable", return_value=True),
+        patch("provider.ZooKeeperProvider.ready", return_value=True),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
+        harness.charm._restart(EventBase)
+
+        patched.assert_called_once()
+
+
+def test_restart_defers_if_not_stable(harness):
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+
+    with (
+        patch(
+            "provider.ZooKeeperProvider.apply_relation_data", return_value=None
+        ) as patched_apply,
+        patch("cluster.ZooKeeperCluster.stable", new_callable=PropertyMock(return_value=False)),
+        patch("provider.ZooKeeperProvider.ready", return_value=True),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+        patch("ops.framework.EventBase.defer") as patched_defer,
+    ):
+        harness.charm._restart(EventBase)
+
+        patched_apply.assert_not_called()
+        patched_defer.assert_called_once()
+
+
+def test_restart_fails_update_relation_data_if_not_ready(harness):
+    with harness.hooks_disabled():
+        _ = harness.add_relation(PEER, CHARM_KEY)
+        harness.set_leader(True)
+
+    with (
+        patch("provider.ZooKeeperProvider.apply_relation_data", return_value=None) as patched,
+        patch("cluster.ZooKeeperCluster.stable", return_value=True),
+        patch("provider.ZooKeeperProvider.ready", new_callable=PropertyMock(return_value=False)),
+        patch("charm.ZooKeeperCharm.config_changed", return_value=True),
+    ):
+        harness.charm._restart(EventBase)
+
+        patched.assert_not_called()
 
 
 def test_init_leader_is_added(harness):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -24,7 +24,7 @@ class DummyClient:
         self.syncing = syncing
         self.ready = ready
         self.SRVR = "Zookeeper version: version\nOutstanding: 0\nMode: leader"
-        self.MNTR = "zk_pending_syncs	0\nzk_peer_state	leading - broadcast"
+        self.MNTR = "zk_pending_syncs	0.0\nzk_peer_state	leading - broadcast"
 
         if self.follower:
             self.SRVR = self.SRVR.replace("leader", "follower")

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -33,23 +33,26 @@ def harness():
 
 
 def test_peer_units_contains_unit(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+
     assert len(harness.charm.cluster.peer_units) == 2
 
 
 def test_started_units_ignores_ready_units(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"state": "ready"}
-    )
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"state": "started"}
-    )
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/3", {"state": "started"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"state": "ready"}
+        )
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"state": "started"}
+        )
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/3", {"state": "started"}
+        )
 
     assert len(harness.charm.cluster.started_units) == 2
 
@@ -65,40 +68,46 @@ def test_get_unit_from_id_succeeds(harness):
 
 
 def test_get_unit_from_id_raises(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
 
     with pytest.raises(UnitNotFoundError):
         harness.charm.cluster.get_unit_from_id(100)
 
 
 def test_unit_config_raises_for_missing_unit(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
 
     with pytest.raises(UnitNotFoundError):
         harness.charm.cluster.get_unit_from_id(100)
 
 
 def test_unit_config_succeeds_for_id(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "treebeard"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "treebeard"}
+        )
 
     harness.charm.cluster.unit_config(unit=1)
 
 
 def test_unit_config_succeeds_for_unit(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
 
     harness.charm.cluster.unit_config(harness.charm.unit)
 
 
 def test_unit_config_has_all_keys(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
+
     config = harness.charm.cluster.unit_config(0)
 
     assert set(config.keys()) == {
@@ -112,9 +121,11 @@ def test_unit_config_has_all_keys(harness):
 
 
 def test_unit_config_server_string_format(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
+
     server_string = harness.charm.cluster.unit_config(0)["server_string"]
     split_string = re.split("=|:|;", server_string)
 
@@ -138,27 +149,32 @@ def test_get_updated_servers(harness):
 
 
 def test_is_unit_turn_succeeds_scaleup(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}",
-        {"0": "added", "1": "added", "2": "added"},
-    )
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}",
+            {"0": "added", "1": "added", "2": "added"},
+        )
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+
     units = sorted(harness.charm.cluster.relation.units, key=lambda x: x.name)
     harness.set_planned_units(1)
+
     assert harness.charm.cluster.is_unit_turn(units[0])
 
 
 def test_is_unit_turn_fails_scaleup(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}",
-        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-    )
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}",
+            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+        )
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+
     units = sorted(harness.charm.cluster.relation.units, key=lambda x: x.name)
     harness.set_planned_units(4)
 
@@ -166,15 +182,17 @@ def test_is_unit_turn_fails_scaleup(harness):
 
 
 def test_is_unit_turn_succeeds_failover(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}",
-        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-    )
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}",
+            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+        )
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+
     units = sorted(harness.charm.cluster.relation.units, key=lambda x: x.name)
     harness.set_planned_units(4)
 
@@ -184,15 +202,17 @@ def test_is_unit_turn_succeeds_failover(harness):
 
 
 def test_is_unit_turn_fails_failover(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}",
-        {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
-    )
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}",
+            {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
+        )
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+
     units = sorted(harness.charm.cluster.relation.units, key=lambda x: x.name)
     harness.set_planned_units(4)
 
@@ -200,20 +220,21 @@ def test_is_unit_turn_fails_failover(harness):
 
 
 def test_generate_units_scaleup_adds_all_servers(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "added"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "added"}
+        )
 
     new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
         "server_string"
@@ -225,44 +246,46 @@ def test_generate_units_scaleup_adds_all_servers(harness):
 
 
 def test_generate_units_scaleup_adds_correct_roles_for_added_units(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "removed"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "removed"}
+        )
 
-    new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
-        "server_string"
-    ]
-    generated_servers = harness.charm.cluster._generate_units(unit_string=new_unit_string)
+        new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
+            "server_string"
+        ]
+        generated_servers = harness.charm.cluster._generate_units(unit_string=new_unit_string)
 
     assert len(re.findall("participant", generated_servers)) == 1
     assert len(re.findall("observer", generated_servers)) == 1
 
 
 def test_generate_units_failover(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}",
-        {"0": "removed", "1": "added", "2": "removed"},
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}",
+            {"0": "removed", "1": "added", "2": "removed"},
+        )
 
     new_unit_string = harness.charm.cluster.unit_config(0, state="ready", role="observer")[
         "server_string"
@@ -273,47 +296,52 @@ def test_generate_units_failover(harness):
 
 
 def test_startup_servers_raises_for_missing_data(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}",
-        {"0": "removed", "sync_password": "Mellon"},
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}",
+            {"0": "removed", "sync_password": "Mellon"},
+        )
 
     with pytest.raises(UnitNotFoundError):
         harness.charm.cluster.startup_servers(unit=2)
 
 
 def test_startup_servers_succeeds_init(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}",
-        {"sync_password": "gollum", "super_password": "precious"},
-    )
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}",
+            {"sync_password": "gollum", "super_password": "precious"},
+        )
+
     harness.set_planned_units(1)
     servers = harness.charm.cluster.startup_servers(unit=0)
+
     assert "observer" not in servers
 
 
 def test_startup_servers_succeeds_failover_after_init(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}",
-        {"0": "removed", "1": "added", "sync_password": "Mellon"},
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}",
+            {"0": "removed", "1": "added", "sync_password": "Mellon"},
+        )
 
     generated_servers = harness.charm.cluster.startup_servers(unit=0)
 
@@ -322,10 +350,13 @@ def test_startup_servers_succeeds_failover_after_init(harness):
 
 
 def test_all_units_related(harness):
-    assert not harness.charm.cluster.all_units_related
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.set_planned_units(2)
-    assert harness.charm.cluster.all_units_related
+    with harness.hooks_disabled():
+        assert not harness.charm.cluster.all_units_related
+
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.set_planned_units(2)
+
+        assert harness.charm.cluster.all_units_related
 
 
 def test_lowest_unit_id_none_if_not_all_related(harness):
@@ -333,8 +364,11 @@ def test_lowest_unit_id_none_if_not_all_related(harness):
 
 
 def test_lowest_unit_id(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+
     harness.set_planned_units(2)
+
     assert harness.charm.cluster.lowest_unit_id == 0
 
 
@@ -343,101 +377,121 @@ def test_stale_quorum_not_all_related(harness):
 
 
 def test_stale_quorum_unit_departed(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": "removed"}
-    )
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": "removed"}
+        )
+
     assert not harness.charm.cluster.stale_quorum
 
 
 def test_stale_quorum_new_unit(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.set_planned_units(2)
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": ""}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.set_planned_units(2)
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": ""}
+        )
 
     assert harness.charm.cluster.stale_quorum
 
 
 def test_stale_quorum_all_added(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.set_planned_units(2)
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": "added"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.set_planned_units(2)
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": "added"}
+        )
+
     assert not harness.charm.cluster.stale_quorum
 
 
 def test_all_rotated_fails(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
+        )
+
     assert not harness.charm.cluster._all_rotated()
 
 
 def test_all_rotated_succeeds(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"password-rotated": "true"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"password-rotated": "true"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
+        )
 
     assert harness.charm.cluster._all_rotated()
 
 
 def test_passwords_set_fails_missing_unit_passwords(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}/0",
-        {"super-password": "mellon", "sync-password": "mellon"},
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}/0",
+            {"super-password": "mellon", "sync-password": "mellon"},
+        )
+
     assert not harness.charm.cluster.passwords_set
 
 
 def test_passwords_set_fails_missing_password(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"super-password": "mellon"}
-    )
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"super-password": "mellon"}
+        )
+
     assert not harness.charm.cluster.passwords_set
 
 
 def test_passwords_set_succeeds(harness):
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id,
-        f"{CHARM_KEY}/0",
-        {"super-password": "mellon", "sync-password": "mellon"},
-    )
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id,
+            f"{CHARM_KEY}/0",
+            {"super-password": "mellon", "sync-password": "mellon"},
+        )
+
     assert not harness.charm.cluster.passwords_set
 
 
 def test_all_units_quorum_fails_wrong_quorum(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"quorum": "non-ssl"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"quorum": "non-ssl"}
+        )
 
-    assert not harness.charm.cluster.all_units_quorum
+        assert not harness.charm.cluster.all_units_quorum
 
-    harness.update_relation_data(harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"})
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"}
+        )
 
-    assert not harness.charm.cluster.all_units_quorum
+        assert not harness.charm.cluster.all_units_quorum
 
 
 def test_all_units_quorum_succeeds(harness):
-    harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-    harness.update_relation_data(harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"})
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
-    )
-    harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"quorum": "ssl"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
+        )
+        harness.update_relation_data(
+            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"quorum": "ssl"}
+        )
 
     assert harness.charm.cluster.all_units_quorum

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -53,37 +53,41 @@ def test_server_jvmflags_has_opts(harness):
 
 
 def test_jaas_users_are_added(harness):
-    harness.add_relation(REL_NAME, "application")
-    harness.update_relation_data(
-        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
-    )
-    harness.update_relation_data(
-        harness.charm.provider.app_relation.id, CHARM_KEY, {"relation-2": "password"}
-    )
+    with harness.hooks_disabled():
+        harness.add_relation(REL_NAME, "application")
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        harness.update_relation_data(
+            harness.charm.provider.app_relation.id, CHARM_KEY, {"relation-2": "password"}
+        )
 
     assert len(harness.charm.zookeeper_config.jaas_users) == 1
 
 
 def test_multiple_jaas_users_are_added(harness):
-    harness.add_relation(REL_NAME, "application")
-    harness.add_relation(REL_NAME, "application2")
-    harness.update_relation_data(
-        harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
-    )
-    harness.update_relation_data(
-        harness.charm.provider.client_relations[1].id, "application2", {"chroot": "app2"}
-    )
-    harness.update_relation_data(
-        harness.charm.provider.app_relation.id,
-        CHARM_KEY,
-        {"relation-2": "password", "relation-3": "password"},
-    )
+    with harness.hooks_disabled():
+        harness.add_relation(REL_NAME, "application")
+        harness.add_relation(REL_NAME, "application2")
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
+        )
+        harness.update_relation_data(
+            harness.charm.provider.client_relations[1].id, "application2", {"chroot": "app2"}
+        )
+        harness.update_relation_data(
+            harness.charm.provider.app_relation.id,
+            CHARM_KEY,
+            {"relation-2": "password", "relation-3": "password"},
+        )
 
     assert len(harness.charm.zookeeper_config.jaas_users) == 2
 
 
 def test_tls_enabled(harness):
-    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
+    with harness.hooks_disabled():
+        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
+
     assert "ssl.clientAuth=none" in harness.charm.zookeeper_config.zookeeper_properties
 
 
@@ -92,32 +96,45 @@ def test_tls_disabled(harness):
 
 
 def test_tls_upgrading(harness):
-    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"upgrading": "started"})
-    assert "portUnification=true" in harness.charm.zookeeper_config.zookeeper_properties
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.tls.cluster.id, CHARM_KEY, {"upgrading": "started"}
+        )
 
-    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"upgrading": ""})
-    assert "portUnification=true" not in harness.charm.zookeeper_config.zookeeper_properties
+        assert "portUnification=true" in harness.charm.zookeeper_config.zookeeper_properties
+
+        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"upgrading": ""})
+
+        assert "portUnification=true" not in harness.charm.zookeeper_config.zookeeper_properties
 
 
 def test_tls_ssl_quorum(harness):
-    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"quorum": "ssl"})
-    assert "sslQuorum=true" in harness.charm.zookeeper_config.zookeeper_properties
+    with harness.hooks_disabled():
+        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"quorum": "ssl"})
 
-    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"quorum": "non-ssl"})
-    assert "sslQuorum=true" not in harness.charm.zookeeper_config.zookeeper_properties
+        assert "sslQuorum=true" in harness.charm.zookeeper_config.zookeeper_properties
+
+        harness.update_relation_data(
+            harness.charm.tls.cluster.id, CHARM_KEY, {"quorum": "non-ssl"}
+        )
+
+        assert "sslQuorum=true" not in harness.charm.zookeeper_config.zookeeper_properties
 
 
 def test_properties_tls_uses_passwords(harness):
-    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
-    harness.update_relation_data(
-        harness.charm.tls.cluster.id, f"{CHARM_KEY}/0", {"keystore-password": "mellon"}
-    )
+    with harness.hooks_disabled():
+        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
+        harness.update_relation_data(
+            harness.charm.tls.cluster.id, f"{CHARM_KEY}/0", {"keystore-password": "mellon"}
+        )
+
     assert "ssl.keyStore.password=mellon" in harness.charm.zookeeper_config.zookeeper_properties
     assert "ssl.trustStore.password=mellon" in harness.charm.zookeeper_config.zookeeper_properties
 
 
 def test_properties_tls_gets_dynamic_config_file_property(harness):
-    harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
+    with harness.hooks_disabled():
+        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
 
     with open("/tmp/zoo.cfg", "w") as fp:
         fp.write("dynamicConfigFile=/gandalf/the/grey")


### PR DESCRIPTION
## tl;dr
Bundles should be more reliable.

## Changes Made
##### `fix: fix bug in client lib where key would be missing`
##### `refactor: call update_quorum on update-status events to recover borked cluster`
- Probably the most helpful change with minimal overhead. Shout out @welpaolo for the idea!
- This helps ensure client applications get refreshed data if, god forbid, events get stuck without being woken up by a `relation-changed` from a peer-unit
- It also helps with quorum stability during scaling operations
##### `refactor: block events if cluster not stable or not ready`
- To avoid issues with bundles attempting a relation during a cluster initialisation 
- TLS relations can be triggered if ever the cluster is no longer scaling/adding units
- Client relations can be triggered if the cluster is not scaling/adding (`stable`) and not installing upgrading to TLS (`ready`)
##### `refactor: add way more debug logs`
- Generally helpful, they were needed to solve the problem, might as well keep them there
##### `refactor: attempt restart of unit for every restart event`
- This ensures that units always are loaded with the most recent config, based on the flags set in the peer relation data
##### `refactor: apply relation data on restart and update_quorum`
- Before this change, clients that related too soon during cluster init would either miss data events, or get incorrect encryption data with TLS
- Every event is now read as a `relation_changed` event, which will call `update_quorum`. `update_quourm` will set peer-data flags, attempt to set relation data. After which, an attempt at a `restart` will be made based on the new peer-data flags changing config or marking upgrades
- In the case of `upgrading`, `restart` will trigger on it's own as it's likely that other units need to get events emitted by the changing of current unit's peer data

## Review Notes
Honestly, this is a beast of a PR and a bit of a mind-melt. If tests pass, I advise those reviewing to take it on good faith that myself and @welpaolo have tested it. But do feel free to dig in!