### PR TITLE
Add tls deps to `charmcraft.yaml`

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -7,6 +7,10 @@ parts:
     charm-binary-python-packages:
       - setuptools
     build-packages:
+      # The following are needed for tls-certificates-interface
+      - build-essential
+      - python3-dev
+      - pkg-config
       - libffi-dev
       - libssl-dev
       - rustc


### PR DESCRIPTION
## Problem
Packing zk fails with:
```
run pkg_config fail: Could not run `"pkg-config" "--libs" "--cflags" "openssl"`
The pkg-config command could not be found.

Most likely, you need to install a pkg-config package for your OS.
Try `apt install pkg-config`, or `yum install pkg-config`,
or `pkg install pkg-config`, or `apk add pkgconfig` depending on your distribution.
```
[charmcraft-20230324-115735.615985.log](https://github.com/canonical/zookeeper-operator/files/11064399/charmcraft-20230324-115735.615985.log)

## Solution
Add deps to `charmcraft.yaml`. With those, packing succeeds.

Recently we had to [do the same with traefik](https://github.com/canonical/traefik-k8s-operator/pull/150). h/t @rbarry82 