### PR TITLE
feat/style: introduce pyright, tidy up errors

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -467,14 +467,14 @@ tests = ["asttokens", "littleutils", "pytest", "rich"]
 
 [[package]]
 name = "google-auth"
-version = "2.16.3"
+version = "2.17.0"
 description = "Google Authentication Library"
 category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 files = [
-    {file = "google-auth-2.16.3.tar.gz", hash = "sha256:611779ce33a3aee265b94b74d4bb8c188f33010f5814761250a0ebbde94cc745"},
-    {file = "google_auth-2.16.3-py2.py3-none-any.whl", hash = "sha256:4dfcfd8ecd1cf03ddc97fddfb3b1f2973ea4f3f664aa0d8cfaf582ef9f0c60e7"},
+    {file = "google-auth-2.17.0.tar.gz", hash = "sha256:f51d26ebb3e5d723b9a7dbd310b6c88654ef1ad1fc35750d1fdba48ca4d82f52"},
+    {file = "google_auth-2.17.0-py2.py3-none-any.whl", hash = "sha256:45ba9b4b3e49406de3c5451697820694b2f6ce8a6b75bb187852fdae231dab94"},
 ]
 
 [package.dependencies]
@@ -1864,4 +1864,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "1e8cc250863246fd260d39319a2926881011ee084fd5f313a9561b49ab7bdce5"
+content-hash = "0ad51ed999e1f670cf53e3a77c24ebb53970c89ae7bc80b8469f6239b12fa7bc"

--- a/poetry.lock
+++ b/poetry.lock
@@ -881,14 +881,14 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "ops"
-version = "2.1.1"
+version = "2.2.0"
 description = "The Python library behind great charms"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ops-2.1.1-py3-none-any.whl", hash = "sha256:bed9f14b785efaa83f89b9c76b87bd1b3b82b0350c453b41dce778b39c7410b4"},
-    {file = "ops-2.1.1.tar.gz", hash = "sha256:b2802068557c64121bf50ccfe101b043ed08c02ac5f958e55752c476b09de63d"},
+    {file = "ops-2.2.0-py3-none-any.whl", hash = "sha256:14d4c43f4a4dc0830af1b2cb21313ef93308d3c389f7bedecc14a70b69000b64"},
+    {file = "ops-2.2.0.tar.gz", hash = "sha256:90fa55249f5c3a7bcb7cc73731227eac867f9bb8426100d10724fe461de142a8"},
 ]
 
 [package.dependencies]
@@ -1000,19 +1000,19 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.1.1"
+version = "3.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.1.1-py3-none-any.whl", hash = "sha256:e5986afb596e4bb5bde29a79ac9061aa955b94fca2399b7aaac4090860920dd8"},
-    {file = "platformdirs-3.1.1.tar.gz", hash = "sha256:024996549ee88ec1a9aa99ff7f8fc819bb59e2c3477b410d90a16d32d6e707aa"},
+    {file = "platformdirs-3.2.0-py3-none-any.whl", hash = "sha256:ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e"},
+    {file = "platformdirs-3.2.0.tar.gz", hash = "sha256:d5b638ca397f25f979350ff789db335903d7ea010ab28903f57b27e1b16c2b08"},
 ]
 
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -1233,14 +1233,14 @@ pytz = "*"
 
 [[package]]
 name = "pyright"
-version = "1.1.300"
+version = "1.1.301"
 description = "Command line wrapper for pyright"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.300-py3-none-any.whl", hash = "sha256:2ff0a21337d1d369e930143f1eed61ba4f225f59ae949631f512722bc9e61e4e"},
-    {file = "pyright-1.1.300.tar.gz", hash = "sha256:1874009c372bb2338e0696d99d915a152977e4ecbef02d3e4a3fd700da699993"},
+    {file = "pyright-1.1.301-py3-none-any.whl", hash = "sha256:ecc3752ba8c866a8041c90becf6be79bd52f4c51f98472e4776cae6d55e12826"},
+    {file = "pyright-1.1.301.tar.gz", hash = "sha256:6ac4afc0004dca3a977a4a04a8ba25b5b5aa55f8289550697bfc20e11be0d5f2"},
 ]
 
 [package.dependencies]
@@ -1367,14 +1367,14 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2022.7.1"
+version = "2023.3"
 description = "World timezone definitions, modern and historical"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2022.7.1-py2.py3-none-any.whl", hash = "sha256:78f4f37d8198e0627c5f1143240bb0206b8691d8d7ac6d78fee88b78733f8c4a"},
-    {file = "pytz-2022.7.1.tar.gz", hash = "sha256:01a0681c4b9684a28304615eba55d1ab31ae00bf68ec157ec3708a8182dbbcd0"},
+    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
+    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
 ]
 
 [[package]]
@@ -1511,14 +1511,14 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "67.6.0"
+version = "67.6.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.6.0-py3-none-any.whl", hash = "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"},
-    {file = "setuptools-67.6.0.tar.gz", hash = "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077"},
+    {file = "setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
+    {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -848,6 +848,21 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.7.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
+    {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "oauthlib"
 version = "3.2.2"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1215,6 +1230,25 @@ files = [
 
 [package.dependencies]
 pytz = "*"
+
+[[package]]
+name = "pyright"
+version = "1.1.300"
+description = "Command line wrapper for pyright"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.300-py3-none-any.whl", hash = "sha256:2ff0a21337d1d369e930143f1eed61ba4f225f59ae949631f512722bc9e61e4e"},
+    {file = "pyright-1.1.300.tar.gz", hash = "sha256:1874009c372bb2338e0696d99d915a152977e4ecbef02d3e4a3fd700da699993"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pyrsistent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ optional = true
 black = "^22.3.0"
 ruff = ">=0.0.157"
 codespell = ">=2.2.2"
+pyright = "^1.1.300"
 
 [tool.poetry.group.unit]
 optional = true
@@ -68,6 +69,10 @@ juju = "==2.9.11"
 coverage = {extras = ["toml"], version = ">7.0"}
 pytest-operator = ">0.20"
 
+
+
+[tool.poetry.group.format.dependencies]
+pyright = "^1.1.300"
 
 [tool.ruff]
 line-length = 99
@@ -93,3 +98,14 @@ target-version="py310"
 
 [tool.ruff.mccabe]
 max-complexity = 10
+
+[tool.pyright]
+include = ["src"]
+extraPaths = ["./lib"]
+pythonVersion = "3.10"
+pythonPlatform = "All"
+typeCheckingMode = "basic"
+reportIncompatibleMethodOverride = false
+reportImportCycles = false
+reportMissingModuleSource = true
+stubPath = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,9 +93,9 @@ cryptography==39.0.2 ; python_version >= "3.8" \
 kazoo==2.9.0 ; python_version >= "3.8" \
     --hash=sha256:800318c7f3dab648cdf616dfb25bdabeefab2a6837aa6951e0fa3ff80e656969 \
     --hash=sha256:b73dd6829ae6b3a78cd37ba393749f9d30860dbe39debb27c36eff159949a14e
-ops==2.1.1 ; python_version >= "3.8" \
-    --hash=sha256:b2802068557c64121bf50ccfe101b043ed08c02ac5f958e55752c476b09de63d \
-    --hash=sha256:bed9f14b785efaa83f89b9c76b87bd1b3b82b0350c453b41dce778b39c7410b4
+ops==2.2.0 ; python_version >= "3.8" \
+    --hash=sha256:14d4c43f4a4dc0830af1b2cb21313ef93308d3c389f7bedecc14a70b69000b64 \
+    --hash=sha256:90fa55249f5c3a7bcb7cc73731227eac867f9bb8426100d10724fe461de142a8
 pure-sasl==0.6.2 ; python_version >= "3.8" \
     --hash=sha256:53c1355f5da95e2b85b2cc9a6af435518edc20c81193faa0eea65fdc835138f4 \
     --hash=sha256:edb33b1a46eb3c602c0166de0442c0fb41f5ac2bfccbde4775183b105ad89ab2

--- a/src/provider.py
+++ b/src/provider.py
@@ -68,6 +68,9 @@ class ZooKeeperProvider(Object):
         if isinstance(event, RelationBrokenEvent) and event.relation.id == relation.id:
             return None
 
+        if not relation.data or not relation.app:
+            return None
+
         # generating username
         username = f"relation-{relation.id}"
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -262,10 +262,11 @@ class ZooKeeperTLS(Object):
 
     def _set_tls_private_key(self, event: ActionEvent) -> None:
         """Handler for `set_tls_private_key` action."""
-        private_key = self._parse_tls_file(event.params.get("internal-key", None))
-        self.cluster.data[self.charm.unit].update({"private-key": private_key})
-
-        self._request_certificate()
+        if private_key := event.params.get("internal-key", None):
+            self.cluster.data[self.charm.unit].update({"private-key": private_key})
+            self._request_certificate()
+        else:
+            event.fail("Could not set key - no internal-key found")
 
     def _request_certificate(self) -> None:
         """Generates and submits CSR to provider."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -18,6 +18,19 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+def application_active(ops_test: OpsTest, expected_units: int) -> bool:
+    units = ops_test.model.applications[APP_NAME].units
+
+    if len(units) != expected_units:
+        return False
+
+    for unit in units:
+        if unit.workload_status != "active":
+            return False
+
+    return True
+
+
 def get_password(model_full_name: str) -> str:
     # getting relation data
     show_unit = check_output(

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -11,7 +11,14 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from .helpers import check_key, get_password, ping_servers, restart_unit, write_key
+from .helpers import (
+    application_active,
+    check_key,
+    get_password,
+    ping_servers,
+    restart_unit,
+    write_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +31,7 @@ async def test_deploy_active(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_units=3
+        apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_exact_units=3
     )
 
     assert ops_test.model.applications[APP_NAME].status == "active"
@@ -33,8 +40,11 @@ async def test_deploy_active(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_simple_scale_up(ops_test: OpsTest):
     await ops_test.model.applications[APP_NAME].add_units(count=3)
+    await ops_test.model.block_until(
+        lambda: application_active(ops_test, expected_units=6), timeout=3600
+    )
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_units=6
+        apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_exact_units=6
     )
     assert ping_servers(ops_test)
 
@@ -44,23 +54,31 @@ async def test_simple_scale_down(ops_test: OpsTest):
     await ops_test.model.applications[APP_NAME].destroy_units(
         f"{APP_NAME}/5", f"{APP_NAME}/4", f"{APP_NAME}/3"
     )
+    await ops_test.model.block_until(
+        lambda: application_active(ops_test, expected_units=3), timeout=1000
+    )
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_units=3
+        apps=[APP_NAME], status="active", timeout=1000, idle_period=30, wait_for_exact_units=3
     )
     assert ping_servers(ops_test)
 
 
 @pytest.mark.abort_on_fail
 async def test_scale_up_replication(ops_test: OpsTest):
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=3600)
+    await ops_test.model.block_until(
+        lambda: application_active(ops_test, expected_units=3), timeout=600
+    )
     assert ping_servers(ops_test)
     host = ops_test.model.applications[APP_NAME].units[0].public_address
     model_full_name = ops_test.model_full_name
     password = get_password(model_full_name or "")
     write_key(host=host, password=password)
     await ops_test.model.applications[APP_NAME].add_units(count=1)
+    await ops_test.model.block_until(
+        lambda: application_active(ops_test, expected_units=4), timeout=3600
+    )
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_exact_units=4
+        apps=[APP_NAME], status="active", timeout=1000, idle_period=30, wait_for_exact_units=4
     )
     check_key(host=host, password=password)
 
@@ -68,58 +86,73 @@ async def test_scale_up_replication(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_kill_quorum_leader_remove(ops_test: OpsTest):
     """Gracefully removes ZK quorum leader using `juju remove`."""
-    await ops_test.model.set_config({"update-status-hook-interval": "1m"})
-    await ops_test.model.applications[APP_NAME].destroy_units(f"{APP_NAME}/0")
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_exact_units=3
-    )
-    assert ping_servers(ops_test)
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+    async with ops_test.fast_forward(fast_interval="1m"):
+        await ops_test.model.applications[APP_NAME].destroy_units(f"{APP_NAME}/0")
+        await ops_test.model.block_until(
+            lambda: application_active(ops_test, expected_units=3), timeout=1000
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME], status="active", timeout=1000, idle_period=30, wait_for_exact_units=3
+        )
+        assert ping_servers(ops_test)
 
 
 @pytest.mark.abort_on_fail
 async def test_kill_juju_leader_remove(ops_test: OpsTest):
     """Gracefully removes Juju leader using `juju remove`."""
-    await ops_test.model.set_config({"update-status-hook-interval": "1m"})
-    leader = None
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader = unit.name
-            break
+    async with ops_test.fast_forward(fast_interval="1m"):
+        leader = None
+        for unit in ops_test.model.applications[APP_NAME].units:
+            if await unit.is_leader_from_status():
+                leader = unit.name
+                break
 
-    if leader:
-        await ops_test.model.applications[APP_NAME].destroy_units(leader)
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_exact_units=2
-        )
-        assert ping_servers(ops_test)
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+        if leader:
+            await ops_test.model.applications[APP_NAME].destroy_units(leader)
+            await ops_test.model.block_until(
+                lambda: application_active(ops_test, expected_units=2), timeout=1000
+            )
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME],
+                status="active",
+                timeout=1000,
+                idle_period=30,
+                wait_for_exact_units=2,
+            )
+            assert ping_servers(ops_test)
 
 
 @pytest.mark.abort_on_fail
 async def test_kill_juju_leader_restart(ops_test: OpsTest):
     """Rudely removes Juju leader by restarting the LXD container."""
-    await ops_test.model.set_config({"update-status-hook-interval": "1m"})
-    leader = None
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader = unit.name
-            break
+    async with ops_test.fast_forward(fast_interval="1m"):
+        leader = None
+        for unit in ops_test.model.applications[APP_NAME].units:
+            if await unit.is_leader_from_status():
+                leader = unit.name
+                break
 
-    if leader:
-        # adding another unit to ensure minimum units for quorum
-        await ops_test.model.applications[APP_NAME].add_units(count=1)
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_exact_units=3
-        )
+        if leader:
+            # adding another unit to ensure minimum units for quorum
+            await ops_test.model.applications[APP_NAME].add_units(count=1)
+            await ops_test.model.block_until(
+                lambda: application_active(ops_test, expected_units=3), timeout=3600
+            )
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME],
+                status="active",
+                timeout=1000,
+                idle_period=30,
+                wait_for_exact_units=3,
+            )
 
-        model_full_name = ops_test.model_full_name
-        if model_full_name:
-            restart_unit(model_full_name=model_full_name, unit=leader)
-            time.sleep(10)
-            assert ping_servers(ops_test)
-        else:
-            raise
+            model_full_name = ops_test.model_full_name
+            if model_full_name:
+                restart_unit(model_full_name=model_full_name, unit=leader)
+                time.sleep(10)
+                assert ping_servers(ops_test)
+            else:
+                raise
 
 
 @pytest.mark.abort_on_fail
@@ -127,12 +160,13 @@ async def test_same_model_application_deploys(ops_test: OpsTest):
     """Ensures that re-deployments of the charm starts on the same model."""
     await asyncio.gather(ops_test.model.applications[APP_NAME].remove())
     charm = await ops_test.build_charm(".")
-    time.sleep(10)
+    time.sleep(30)
     await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+    await ops_test.model.block_until(
+        lambda: application_active(ops_test, expected_units=3), timeout=3600
+    )
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_exact_units=3
     )
 
     assert ops_test.model.applications[APP_NAME].status == "active"
-
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,6 @@ commands =
     poetry run coverage run --source={[vars]src_path} \
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     poetry run coverage report
-    poetry run coverage xml
 
 [testenv:integration]
 description = Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,9 @@ commands =
     poetry run ruff {[vars]all_path}
     poetry run black --check --diff {[vars]all_path}
 
+    poetry install
+    poetry run pyright
+
 [testenv:unit]
 description = Run unit tests
 commands =


### PR DESCRIPTION
## Changes Made
##### `style/feat: introduce pyright static type checking`
- Gets used in `tox -e lint` for simplicity (no need to add a new command)
- If you want to have type warnings appear normally during development, if you're using VSCode as your editor, ensure you have the `ms-python.python` extension, and add the following to your `settings.json`:
    ```
    "python.analysis.extraPaths": ["./lib"],
    "typeCheckingMode": "basic"
    ```