### PR TITLE
refactor: extend jujuignore, add typehints, remove excess peer_relations

### DIFF
--- a/.jujuignore
+++ b/.jujuignore
@@ -1,3 +1,10 @@
-/venv
-*.py[cod]
+venv/
+build/
 *.charm
+.tox/
+.coverage
+__pycache__/
+*.py[cod]
+.vscode
+.idea
+.python-version

--- a/poetry.lock
+++ b/poetry.lock
@@ -467,14 +467,14 @@ tests = ["asttokens", "littleutils", "pytest", "rich"]
 
 [[package]]
 name = "google-auth"
-version = "2.17.0"
+version = "2.17.1"
 description = "Google Authentication Library"
 category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 files = [
-    {file = "google-auth-2.17.0.tar.gz", hash = "sha256:f51d26ebb3e5d723b9a7dbd310b6c88654ef1ad1fc35750d1fdba48ca4d82f52"},
-    {file = "google_auth-2.17.0-py2.py3-none-any.whl", hash = "sha256:45ba9b4b3e49406de3c5451697820694b2f6ce8a6b75bb187852fdae231dab94"},
+    {file = "google-auth-2.17.1.tar.gz", hash = "sha256:8f379b46bad381ad2a0b989dfb0c13ad28d3c2a79f27348213f8946a1d15d55a"},
+    {file = "google_auth-2.17.1-py2.py3-none-any.whl", hash = "sha256:357ff22a75b4c0f6093470f21816a825d2adee398177569824e37b6c10069e19"},
 ]
 
 [package.dependencies]
@@ -552,14 +552,14 @@ tomli = {version = "*", markers = "python_version > \"3.6\" and python_version <
 
 [[package]]
 name = "ipython"
-version = "8.11.0"
+version = "8.12.0"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ipython-8.11.0-py3-none-any.whl", hash = "sha256:5b54478e459155a326bf5f42ee4f29df76258c0279c36f21d71ddb560f88b156"},
-    {file = "ipython-8.11.0.tar.gz", hash = "sha256:735cede4099dbc903ee540307b9171fbfef4aa75cfcacc5a273b2cda2f02be04"},
+    {file = "ipython-8.12.0-py3-none-any.whl", hash = "sha256:1c183bf61b148b00bcebfa5d9b39312733ae97f6dad90d7e9b4d86c8647f498c"},
+    {file = "ipython-8.12.0.tar.gz", hash = "sha256:a950236df04ad75b5bc7f816f9af3d74dc118fd42f2ff7e80e8e60ca1f182e2d"},
 ]
 
 [package.dependencies]
@@ -575,6 +575,7 @@ prompt-toolkit = ">=3.0.30,<3.0.37 || >3.0.37,<3.1.0"
 pygments = ">=2.4.0"
 stack-data = "*"
 traitlets = ">=5"
+typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
 
 [package.extras]
 all = ["black", "curio", "docrepr", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.21)", "pandas", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
@@ -651,13 +652,13 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "juju"
-version = "2.9.11"
+version = "3.0.4"
 description = "Python library for Juju"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "juju-2.9.11.tar.gz", hash = "sha256:27bbb93c6764bf9f98f1f87a5ce5c95037fc5ef898f48ae56b5c101286a1ab59"},
+    {file = "juju-3.0.4.tar.gz", hash = "sha256:1bb36132604f41badb9c5de1d43a4c60b4da7c5890abc5f8977ff149924440f5"},
 ]
 
 [package.dependencies]
@@ -1484,29 +1485,29 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruff"
-version = "0.0.259"
+version = "0.0.260"
 description = "An extremely fast Python linter, written in Rust."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.0.259-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:f3938dc45e2a3f818e9cbd53007265c22246fbfded8837b2c563bf0ebde1a226"},
-    {file = "ruff-0.0.259-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:22e1e35bf5f12072cd644d22afd9203641ccf258bc14ff91aa1c43dc14f6047d"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2fb20e89e85d147c85caa807707a1488bccc1f3854dc3d53533e89b52a0c5ff"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49e903bcda19f6bb0725a962c058eb5d61f40d84ef52ed53b61939b69402ab4e"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:71f0ef1985e9a6696fa97da8459917fa34bdaa2c16bd33bd5edead585b7d44f7"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7cfef26619cba184d59aa7fa17b48af5891d51fc0b755a9bc533478a10d4d066"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79b02fa17ec1fd8d306ae302cb47fb614b71e1f539997858243769bcbe78c6d9"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:428507fb321b386dda70d66cd1a8aa0abf51d7c197983d83bb9e4fa5ee60300b"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5fbaea9167f1852757f02133e5daacdb8c75b3431343205395da5b10499927a"},
-    {file = "ruff-0.0.259-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:40ae87f2638484b7e8a7567b04a7af719f1c484c5bf132038b702bb32e1f6577"},
-    {file = "ruff-0.0.259-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:29e2b77b7d5da6a7dd5cf9b738b511355c5734ece56f78e500d4b5bffd58c1a0"},
-    {file = "ruff-0.0.259-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b3c1beacf6037e7f0781d4699d9a2dd4ba2462f475be5b1f45cf84c4ba3c69d"},
-    {file = "ruff-0.0.259-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:daaea322e7e85f4c13d82be9536309e1c4b8b9851bb0cbc7eeb15d490fd46bf9"},
-    {file = "ruff-0.0.259-py3-none-win32.whl", hash = "sha256:38704f151323aa5858370a2f792e122cc25e5d1aabe7d42ceeab83da18f0b456"},
-    {file = "ruff-0.0.259-py3-none-win_amd64.whl", hash = "sha256:aa9449b898287e621942cc71b9327eceb8f0c357e4065fecefb707ef2d978df8"},
-    {file = "ruff-0.0.259-py3-none-win_arm64.whl", hash = "sha256:e4f39e18702de69faaaee3969934b92d7467285627f99a5b6ecd55a7d9f5d086"},
-    {file = "ruff-0.0.259.tar.gz", hash = "sha256:8b56496063ab3bfdf72339a5fbebb8bd46e5c5fee25ef11a9f03b208fa0562ec"},
+    {file = "ruff-0.0.260-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:c559650b623f3fbdc39c7ed1bcb064765c666a53ee738c53d1461afbf3f23db2"},
+    {file = "ruff-0.0.260-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:90ff1479e292a84c388a8a035d223247ddeea5f6760752a9142b88b6d59ac334"},
+    {file = "ruff-0.0.260-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25584d1b9f445fde72651caab97e7430a4c5bfd2a0ce9af39868753826cba10d"},
+    {file = "ruff-0.0.260-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8032e35357384a29791c75194a71e314031171eb0731fcaa872dfaf4c1f4470a"},
+    {file = "ruff-0.0.260-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e4fa7293f97c021825b3b72f2bf53f0eb4f59625608a889678c1fc6660f412d"},
+    {file = "ruff-0.0.260-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8bec0271e2c8cd36bcf915cb9f6a93e40797a3ff3d2cda4ca87b7bed9e598472"},
+    {file = "ruff-0.0.260-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e075a61aaff8ebe56172217f0ac14c5df9637b289bf161ac697445a9003d5c2"},
+    {file = "ruff-0.0.260-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8678f54eb2696481618902a10c3cb28325f3323799af99997ad6f06005ea4f5"},
+    {file = "ruff-0.0.260-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57d9f0bfdef739b76aa3112b9182a214f0f34589a2659f88353492c7670fe2fe"},
+    {file = "ruff-0.0.260-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ec1f77219ba5adaa194289cb82ba924ff2ed931fd00b8541d66a1724c89fbc9"},
+    {file = "ruff-0.0.260-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aae2170a7ec6f7fc4a73db30aa7aa7fce936176bf66bf85f77f69ddd1dd4a665"},
+    {file = "ruff-0.0.260-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5f847b72ef994ab88e9da250c7eb5cbb3f1555b92a9f22c5ed1c27a44b7e98d6"},
+    {file = "ruff-0.0.260-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6dd705d4eff405c2b70513188fbff520f49db6df91f0d5e8258c5d469efa58bc"},
+    {file = "ruff-0.0.260-py3-none-win32.whl", hash = "sha256:3866a96b2ef92c7d837ba6bf8fc9dd125a67886f1c5512ad6fa5d5fefaceff87"},
+    {file = "ruff-0.0.260-py3-none-win_amd64.whl", hash = "sha256:0733d524946decbd4f1e63f7dc26820f5c1e6c31da529ba20fb995057f8e79b1"},
+    {file = "ruff-0.0.260-py3-none-win_arm64.whl", hash = "sha256:12542a26f189a5a10c719bfa14d415d0511ac05e5c9ff5e79cc9d5cc50b81bc8"},
+    {file = "ruff-0.0.260.tar.gz", hash = "sha256:ea8f94262f33b81c47ee9d81f455b144e94776f5c925748cb0c561a12206eae1"},
 ]
 
 [[package]]
@@ -1864,4 +1865,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "0ad51ed999e1f670cf53e3a77c24ebb53970c89ae7bc80b8469f6239b12fa7bc"
+content-hash = "14fc3b199c0f97497cb8da3b8d97f529e5c3bd6c6786e67499932c218aeea344"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ optional = true
 
 [tool.poetry.group.integration.dependencies]
 pytest = ">=7.2"
-juju = "==2.9.11"
+juju = "<3.1"  # The latest python-libjuju that supports both juju 2.9 and 3.0
 coverage = {extras = ["toml"], version = ">7.0"}
 pytest-operator = ">0.20"
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,12 +6,13 @@
 
 import logging
 import time
+from collections.abc import MutableMapping
 
-from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider, Optional, Relation
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from cluster import ZooKeeperCluster
 from config import ZooKeeperConfig
-from literals import CHARM_KEY, CHARM_USERS, JMX_PORT, METRICS_PROVIDER_PORT
+from literals import CHARM_KEY, CHARM_USERS, JMX_PORT, METRICS_PROVIDER_PORT, PEER
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -80,6 +81,27 @@ class ZooKeeperCharm(CharmBase):
         )
         self.framework.observe(getattr(self.on, "set_password_action"), self._set_password_action)
 
+    @property
+    def peer_relation(self) -> Optional[Relation]:
+        """The cluster peer relation."""
+        return self.model.get_relation(PEER)
+
+    @property
+    def app_peer_data(self) -> MutableMapping[str, str]:
+        """Application peer relation data object."""
+        if not self.peer_relation:
+            return {}
+
+        return self.peer_relation.data[self.app]
+
+    @property
+    def unit_peer_data(self) -> MutableMapping[str, str]:
+        """Unit peer relation data object."""
+        if not self.peer_relation:
+            return {}
+
+        return self.peer_relation.data[self.unit]
+
     def _on_install(self, event: InstallEvent) -> None:
         """Handler for the `on_install` event."""
         self.unit.status = MaintenanceStatus("installing ZooKeeper Snap")
@@ -89,7 +111,7 @@ class ZooKeeperCharm(CharmBase):
             self.unit.status = BlockedStatus("unable to install ZooKeeper Snap")
 
         # don't complete install until passwords set
-        if not self.cluster.relation:
+        if not self.peer_relation:
             self.unit.status = WaitingStatus("waiting for peer relation")
             event.defer()
             return
@@ -98,12 +120,12 @@ class ZooKeeperCharm(CharmBase):
 
         # give the leader a default quorum during cluster initialisation
         if self.unit.is_leader():
-            self.cluster.relation.data[self.app].update({"quorum": "default - non-ssl"})
+            self.app_peer_data.update({"quorum": "default - non-ssl"})
 
     def _on_cluster_relation_changed(self, event: EventBase) -> None:
         """Generic handler for all 'something changed, update' events across all relations."""
         # not all methods called
-        if not self.cluster.relation:
+        if not self.peer_relation:
             self.unit.status = WaitingStatus("waiting for peer relation")
             return
 
@@ -148,10 +170,10 @@ class ZooKeeperCharm(CharmBase):
         self.unit.status = ActiveStatus()
 
         # Indicate that unit has completed restart on password rotation
-        if self.cluster.relation.data[self.app].get("rotate-passwords"):
-            self.cluster.relation.data[self.unit]["password-rotated"] = "true"
+        if self.app_peer_data.get("rotate-passwords"):
+            self.unit_peer_data["password-rotated"] = "true"
 
-        self.cluster.relation.data[self.unit].update(
+        self.unit_peer_data.update(
             {
                 # flag to declare unit running `portUnification` during ssl<->no-ssl upgrade
                 "unified": "true" if self.tls.upgrading else "",
@@ -203,7 +225,7 @@ class ZooKeeperCharm(CharmBase):
         logger.info(f"Server.{self.cluster.get_unit_id(self.unit)} started")
 
         # added here in case a `restart` was missed
-        self.cluster.relation.data[self.unit].update(
+        self.unit_peer_data.update(
             {
                 "state": "started",
                 "unified": "true" if self.tls.upgrading else "",
@@ -258,8 +280,8 @@ class ZooKeeperCharm(CharmBase):
             return
 
         if not self.cluster.passwords_set:
-            self.cluster.relation.data[self.app].update({"sync-password": generate_password()})
-            self.cluster.relation.data[self.app].update({"super-password": generate_password()})
+            self.app_peer_data.update({"sync-password": generate_password()})
+            self.app_peer_data.update({"super-password": generate_password()})
 
     def update_quorum(self, event: EventBase) -> None:
         """Updates the server quorum members for all currently started units in the relation.
@@ -282,7 +304,7 @@ class ZooKeeperCharm(CharmBase):
             updated_servers = self.cluster.update_cluster()
             logger.debug(f"{updated_servers=}")
             # triggers a `cluster_relation_changed` to wake up following units
-            self.cluster.relation.data[self.app].update(updated_servers)
+            self.app_peer_data.update(updated_servers)
 
         # default startup without ssl relation
         logger.debug("updating quorum - checking cluster stability")
@@ -295,14 +317,14 @@ class ZooKeeperCharm(CharmBase):
             logger.debug("all units unified")
             if self.tls.enabled:
                 logger.debug("tls enabled - switching to ssl")
-                self.cluster.relation.data[self.app].update({"quorum": "ssl"})
+                self.app_peer_data.update({"quorum": "ssl"})
             else:
                 logger.debug("tls disabled - switching to non-ssl")
-                self.cluster.relation.data[self.app].update({"quorum": "non-ssl"})
+                self.app_peer_data.update({"quorum": "non-ssl"})
 
             if self.cluster.all_units_quorum:
                 logger.debug("all units running desired encryption - removing upgrading")
-                self.cluster.relation.data[self.app].update({"upgrading": ""})
+                self.app_peer_data.update({"upgrading": ""})
                 logger.info(f"ZooKeeper cluster switching to {self.cluster.quorum} quorum")
 
         if self.provider.ready:
@@ -316,14 +338,12 @@ class ZooKeeperCharm(CharmBase):
         # units need to exist in the app data to be iterated through for next_turn
         for unit in self.cluster.started_units:
             unit_id = self.cluster.get_unit_id(unit)
-            current_value = self.cluster.relation.data[self.app].get(str(unit_id), None)
+            current_value = self.app_peer_data.get(str(unit_id), None)
 
             # sets to "added" for init quorum leader, if not already exists
             # may already exist if during the case of a failover of the first unit
             if unit_id == self.cluster.lowest_unit_id:
-                self.cluster.relation.data[self.app].update(
-                    {str(unit_id): current_value or "added"}
-                )
+                self.app_peer_data.update({str(unit_id): current_value or "added"})
 
     def rotate_passwords(self) -> bool:
         """Handle password rotation and check the status of the process.
@@ -335,14 +355,14 @@ class ZooKeeperCharm(CharmBase):
             bool: True when password rotation is finished, false otherwise.
         """
         # Logic for password rotation
-        if self.cluster.relation.data[self.app].get("rotate-passwords"):
+        if self.app_peer_data.get("rotate-passwords"):
             # All units have rotated the password, we can remove the global flag
             if self.unit.is_leader() and self.cluster._all_rotated():
-                self.cluster.relation.data[self.app]["rotate-passwords"] = ""
+                self.app_peer_data["rotate-passwords"] = ""
                 return False
 
             # Own unit finished rotation, no need to issue a new lock
-            if self.cluster.relation.data[self.unit].get("password-rotated"):
+            if self.unit_peer_data.get("password-rotated"):
                 return False
 
             logger.info("Acquiring lock for password rotation")
@@ -352,7 +372,7 @@ class ZooKeeperCharm(CharmBase):
         else:
             # After removal of global flag, each unit can reset its state so more
             # password rotations can happen
-            self.cluster.relation.data[self.unit]["password-rotated"] = ""
+            self.unit_peer_data["password-rotated"] = ""
             return True
 
     def _get_super_password_action(self, event: ActionEvent) -> None:
@@ -390,10 +410,10 @@ class ZooKeeperCharm(CharmBase):
             return
 
         # Store those passwords on application databag
-        self.cluster.relation.data[self.app].update({f"{username}-password": new_password})
+        self.app_peer_data.update({f"{username}-password": new_password})
 
         # Add password flag
-        self.cluster.relation.data[self.app]["rotate-passwords"] = "true"
+        self.app_peer_data["rotate-passwords"] = "true"
         event.set_results({f"{username}-password": new_password})
 
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -17,8 +17,7 @@ from charms.zookeeper.v0.client import (
 )
 from kazoo.exceptions import BadArgumentsError
 from kazoo.handlers.threading import KazooTimeoutError
-from literals import PEER
-from ops.model import Relation, Unit
+from ops.model import Unit
 
 logger = logging.getLogger(__name__)
 
@@ -50,22 +49,16 @@ class ZooKeeperCluster:
         self.election_port = election_port
 
     @property
-    def relation(self) -> Relation:
-        """Relation property to be used by both the instance and charm.
-
-        Returns:
-            The peer relation instance
-        """
-        return self.charm.model.get_relation(PEER)
-
-    @property
     def peer_units(self) -> Set[Unit]:
         """Grabs all units in the current peer relation, including the running unit.
 
         Returns:
             Set of units in the current peer relation, including the running unit
         """
-        return set([self.charm.unit] + list(self.relation.units))
+        if not self.charm.relation:
+            return set()
+
+        return set([self.charm.unit] + list(self.charm.peer_relation.units))
 
     @property
     def all_units_related(self) -> bool:
@@ -105,7 +98,7 @@ class ZooKeeperCluster:
         """
         started_units = set()
         for unit in self.peer_units:
-            if self.relation.data[unit].get("state", None) == "started":
+            if self.charm.peer_relation.data[unit].get("state", None) == "started":
                 started_units.add(unit)
 
         return started_units
@@ -137,7 +130,7 @@ class ZooKeeperCluster:
         """
         for unit in self.peer_units:
             unit_id = self.get_unit_id(unit)
-            if self.relation.data[self.charm.app].get(str(unit_id), None) != "added":
+            if self.charm.app_peer_data.get(str(unit_id), None) != "added":
                 logger.debug(f"Unit {unit.name} needs adding")
                 return False
 
@@ -246,7 +239,7 @@ class ZooKeeperCluster:
             unit = self.get_unit_from_id(unit)
 
         try:
-            host = self.relation.data[unit]["private-address"]
+            host = self.charm.peer_relation.data[unit]["private-address"]
         except KeyError:
             raise UnitNotFoundError
 
@@ -352,7 +345,7 @@ class ZooKeeperCluster:
 
         for peer_id in range(self.lowest_unit_id, unit_id):
             # missing relation data unit ids means that they are not yet added to quorum
-            if not self.relation.data[self.charm.app].get(str(peer_id), None):
+            if not self.charm.app_peer_data.get(str(peer_id), None):
                 return False
 
         return True
@@ -360,7 +353,7 @@ class ZooKeeperCluster:
     def _is_init_leader(self, unit_id: int) -> bool:
         """Checks if the passed unit should be the first unit to start."""
         # if lowest_unit_id, and it exists in the relation data already, it's a restart, fail
-        if int(unit_id) == self.lowest_unit_id and not self.relation.data[self.charm.app].get(
+        if int(unit_id) == self.lowest_unit_id and not self.charm.app_peer_data.get(
             str(self.lowest_unit_id), None
         ):
             return True
@@ -370,7 +363,7 @@ class ZooKeeperCluster:
     def _generate_units(self, unit_string: str) -> str:
         """Gets valid start-up server strings for current ZK quorum units found in the app data."""
         servers = ""
-        for unit_id, state in self.relation.data[self.charm.app].items():
+        for unit_id, state in self.charm.app_peer_data.items():
             if state == "added":
                 try:
                     server_string = self.unit_config(unit=int(unit_id))["server_string"]
@@ -418,7 +411,7 @@ class ZooKeeperCluster:
         """
         all_finished = True
         for unit in self.peer_units:
-            if self.relation.data[unit].get("password-rotated") is None:
+            if self.charm.peer_relation.data[unit].get("password-rotated") is None:
                 all_finished = False
                 break
         return all_finished
@@ -430,8 +423,8 @@ class ZooKeeperCluster:
         Returns:
             Tuple of super_password, sync_password
         """
-        super_password = str(self.relation.data[self.charm.app].get("super-password", ""))
-        sync_password = str(self.relation.data[self.charm.app].get("sync-password", ""))
+        super_password = str(self.charm.app_peer_data.get("super-password", ""))
+        sync_password = str(self.charm.app_peer_data.get("sync-password", ""))
 
         return super_password, sync_password
 
@@ -455,7 +448,7 @@ class ZooKeeperCluster:
         Returns:
             True if the unit has started. Otherwise False
         """
-        return self.relation.data[self.charm.unit].get("state", None) == "started"
+        return self.charm.unit_peer_data.get("state", None) == "started"
 
     @property
     def quorum(self) -> str:
@@ -464,7 +457,7 @@ class ZooKeeperCluster:
         Returns:
             String of either `ssl` or `non-ssl`. Defaults `non-ssl`.
         """
-        return self.relation.data[self.charm.app].get("quorum", "default - non-ssl")
+        return self.charm.app_peer_data.get("quorum", "default - non-ssl")
 
     @property
     def all_units_quorum(self) -> bool:
@@ -476,7 +469,7 @@ class ZooKeeperCluster:
         """
         unit_quorums = set()
         for unit in self.peer_units:
-            unit_quorum = self.relation.data[unit].get("quorum", None)
+            unit_quorum = self.charm.peer_relation.data[unit].get("quorum", None)
             if unit_quorum != self.quorum:
                 logger.debug(
                     f"not all units quorum - {unit.name} has {unit_quorum}, cluster has {self.quorum}"

--- a/src/config.py
+++ b/src/config.py
@@ -7,8 +7,7 @@
 import logging
 from typing import List
 
-from literals import JMX_PORT, METRICS_PROVIDER_PORT, PEER, REL_NAME
-from ops.model import Relation
+from literals import JMX_PORT, METRICS_PROVIDER_PORT, REL_NAME
 from utils import safe_get_file, safe_write_to_file
 
 logger = logging.getLogger(__name__)
@@ -59,15 +58,6 @@ class ZooKeeperConfig:
         self.jmx_prometheus_config_filepath = f"{self.charm.snap.conf_path}/jmx_prometheus.yaml"
 
     @property
-    def cluster(self) -> Relation:
-        """Relation property to be used by both the instance and charm.
-
-        Returns:
-            The peer relation instance
-        """
-        return self.charm.model.get_relation(PEER)
-
-    @property
     def server_jvmflags(self) -> List[str]:
         """Builds necessary server JVM flag env-vars for the ZooKeeper Snap."""
         return [
@@ -99,7 +89,7 @@ class ZooKeeperConfig:
         jaas_users = []
         for relation in client_relations:
             username = f"relation-{relation.id}"
-            password = self.cluster.data[self.charm.app].get(username, None)
+            password = self.charm.app_peer_data.get(username, None)
 
             if not (username and password):
                 continue
@@ -122,8 +112,8 @@ class ZooKeeperConfig:
         Returns:
             String of JAAS config for super/user config
         """
-        sync_password = self.cluster.data[self.charm.app].get("sync-password", None)
-        super_password = self.cluster.data[self.charm.app].get("super-password", None)
+        sync_password = self.charm.app_peer_data.get("sync-password", None)
+        super_password = self.charm.app_peer_data.get("super-password", None)
         users = "\n".join(self.jaas_users) or ""
 
         return f"""

--- a/src/config.py
+++ b/src/config.py
@@ -5,10 +5,13 @@
 """Manager for handling ZooKeeper auth configuration."""
 
 import logging
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from literals import JMX_PORT, METRICS_PROVIDER_PORT, REL_NAME
 from utils import safe_get_file, safe_write_to_file
+
+if TYPE_CHECKING:
+    from charm import ZooKeeperCharm
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +48,7 @@ class ZooKeeperConfig:
     """Manager for handling ZooKeeper auth configuration."""
 
     def __init__(self, charm):
-        self.charm = charm
+        self.charm: "ZooKeeperCharm" = charm
         self.properties_filepath = f"{self.charm.snap.conf_path}/zoo.cfg"
         self.log4j_properties_filepath = f"{self.charm.snap.conf_path}/log4j.properties"
         self.dynamic_filepath = f"{self.charm.snap.conf_path}/zookeeper-dynamic.properties"

--- a/src/provider.py
+++ b/src/provider.py
@@ -17,7 +17,7 @@ from charms.zookeeper.v0.client import (
 from cluster import UnitNotFoundError
 from kazoo.handlers.threading import KazooTimeoutError
 from kazoo.security import ACL, make_acl
-from literals import PEER, REL_NAME
+from literals import REL_NAME
 from ops.charm import RelationBrokenEvent, RelationEvent
 from ops.framework import EventBase, Object
 from ops.model import Relation
@@ -40,11 +40,6 @@ class ZooKeeperProvider(Object):
         self.framework.observe(
             self.charm.on[REL_NAME].relation_broken, self._on_client_relation_broken
         )
-
-    @property
-    def app_relation(self) -> Relation:
-        """Gets the current ZK peer relation."""
-        return self.charm.model.get_relation(PEER)
 
     @property
     def client_relations(self) -> List[Relation]:
@@ -75,7 +70,7 @@ class ZooKeeperProvider(Object):
         username = f"relation-{relation.id}"
 
         # Default to empty string in case passwords not set
-        password = self.app_relation.data[self.charm.app].get(username, "")
+        password = self.charm.app_peer_data.get(username, "")
         if password:
             acls_added = "true"
         else:
@@ -295,7 +290,7 @@ class ZooKeeperProvider(Object):
         if relation_config and relation_config.get("acls-added"):
             logger.debug(f"updating passwords for {getattr(event.app, 'name', None)}")
             # triggers relation_changed for other units to restart
-            self.app_relation.data[self.charm.app].update(
+            self.charm.app_peer_data.update(
                 {relation_config["username"]: relation_config["password"]}
             )
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -18,10 +18,9 @@ from charms.tls_certificates_interface.v1.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from literals import PEER
 from ops.charm import ActionEvent, RelationCreatedEvent, RelationJoinedEvent
 from ops.framework import Object
-from ops.model import Relation, Unit
+from ops.model import Unit
 from utils import generate_password, safe_write_to_file
 
 logger = logging.getLogger(__name__)
@@ -61,15 +60,6 @@ class ZooKeeperTLS(Object):
         )
 
     @property
-    def cluster(self) -> Relation:
-        """Relation property to be used by both the instance and charm.
-
-        Returns:
-            The peer relation instance
-        """
-        return self.charm.model.get_relation(PEER)
-
-    @property
     def private_key(self) -> Optional[str]:
         """The unit private-key set during `certificates_joined`.
 
@@ -77,7 +67,7 @@ class ZooKeeperTLS(Object):
             String of key contents
             None if key not yet generated
         """
-        return self.cluster.data[self.charm.unit].get("private-key", None)
+        return self.charm.unit_peer_data.get("private-key", None)
 
     @property
     def keystore_password(self) -> Optional[str]:
@@ -90,7 +80,7 @@ class ZooKeeperTLS(Object):
             String of password
             None if password not yet generated
         """
-        return self.cluster.data[self.charm.unit].get("keystore-password", None)
+        return self.charm.unit_peer_data.get("keystore-password", None)
 
     @property
     def csr(self) -> Optional[str]:
@@ -100,7 +90,7 @@ class ZooKeeperTLS(Object):
             String of csr contents
             None if csr not yet generated
         """
-        return self.cluster.data[self.charm.unit].get("csr", None)
+        return self.charm.unit_peer_data.get("csr", None)
 
     @property
     def certificate(self) -> Optional[str]:
@@ -110,7 +100,7 @@ class ZooKeeperTLS(Object):
             String of cert contents in PEM format
             None if cert not yet generated/signed
         """
-        return self.cluster.data[self.charm.unit].get("certificate", None)
+        return self.charm.unit_peer_data.get("certificate", None)
 
     @property
     def ca(self) -> Optional[str]:
@@ -120,7 +110,7 @@ class ZooKeeperTLS(Object):
             String of ca contents in PEM format
             None if cert not yet generated/signed
         """
-        return self.cluster.data[self.charm.unit].get("ca", None)
+        return self.charm.unit_peer_data.get("ca", None)
 
     @property
     def enabled(self) -> bool:
@@ -129,7 +119,7 @@ class ZooKeeperTLS(Object):
         Returns:
             True if SSL quorum encryption should be active. Otherwise False
         """
-        return self.cluster.data[self.charm.app].get("tls", None) == "enabled"
+        return self.charm.app_peer_data.get("tls", None) == "enabled"
 
     @property
     def upgrading(self) -> bool:
@@ -138,7 +128,7 @@ class ZooKeeperTLS(Object):
         Returns:
             True if the cluster is switching. Otherwise False
         """
-        return bool(self.cluster.data[self.charm.app].get("upgrading", None) == "started")
+        return bool(self.charm.app_peer_data.get("upgrading", None) == "started")
 
     def unit_unified(self, unit: Unit) -> bool:
         """Checks if the unit is running `portUnification` configuration option.
@@ -182,7 +172,7 @@ class ZooKeeperTLS(Object):
         # if this event fired, we don't know whether the cluster was fully running or not
         # assume it's already running, and trigger `upgrade` from non-ssl -> ssl
         # ideally trigger this before any other `certificates_*` step
-        self.cluster.data[self.charm.app].update({"tls": "enabled", "upgrading": "started"})
+        self.charm.app_peer_data.update({"tls": "enabled", "upgrading": "started"})
 
     def _on_certificates_joined(self, event: RelationJoinedEvent) -> None:
         """Handler for `certificates_relation_joined` event."""
@@ -195,13 +185,13 @@ class ZooKeeperTLS(Object):
 
         # generate unit private key if not already created by action
         if not self.private_key:
-            self.cluster.data[self.charm.unit].update(
+            self.charm.unit_peer_data.update(
                 {"private-key": generate_private_key().decode("utf-8")}
             )
 
         # generate unit keystore password if not already created by action
         if not self.keystore_password:
-            self.cluster.data[self.charm.unit].update({"keystore-password": generate_password()})
+            self.charm.unit_peer_data.update({"keystore-password": generate_password()})
 
         self._request_certificate()
 
@@ -216,9 +206,7 @@ class ZooKeeperTLS(Object):
         if self.certificate:
             self.charm.on[f"{self.charm.restart.name}"].acquire_lock.emit()
 
-        self.cluster.data[self.charm.unit].update(
-            {"certificate": event.certificate, "ca": event.ca}
-        )
+        self.charm.unit_peer_data.update({"certificate": event.certificate, "ca": event.ca})
 
         self.set_server_key()
         self.set_ca()
@@ -230,7 +218,7 @@ class ZooKeeperTLS(Object):
 
     def _on_certificates_broken(self, _) -> None:
         """Handler for `certificates_relation_broken` event."""
-        self.cluster.data[self.charm.unit].update({"csr": "", "certificate": "", "ca": ""})
+        self.charm.unit_peer_data.update({"csr": "", "certificate": "", "ca": ""})
 
         # remove all existing keystores from the unit so we don't preserve certs
         self.remove_stores()
@@ -240,7 +228,7 @@ class ZooKeeperTLS(Object):
 
         # if this event fired, trigger `upgrade` from ssl -> non-ssl
         # ideally trigger this before any other `certificates_*` step
-        self.cluster.data[self.charm.app].update({"tls": "", "upgrading": "started"})
+        self.charm.app_peer_data.update({"tls": "", "upgrading": "started"})
 
     def _on_certificate_expiring(self, _) -> None:
         """Handler for `certificate_expiring` event."""
@@ -258,12 +246,12 @@ class ZooKeeperTLS(Object):
             new_certificate_signing_request=new_csr,
         )
 
-        self.cluster.data[self.charm.unit].update({"csr": new_csr.decode("utf-8").strip()})
+        self.charm.unit_peer_data.update({"csr": new_csr.decode("utf-8").strip()})
 
     def _set_tls_private_key(self, event: ActionEvent) -> None:
         """Handler for `set_tls_private_key` action."""
         if private_key := event.params.get("internal-key", None):
-            self.cluster.data[self.charm.unit].update({"private-key": private_key})
+            self.charm.unit_peer_data.update({"private-key": private_key})
             self._request_certificate()
         else:
             event.fail("Could not set key - no internal-key found")
@@ -279,7 +267,7 @@ class ZooKeeperTLS(Object):
             subject=self.charm.cluster.unit_config(unit=self.charm.unit)["host"],
             **self._sans,
         )
-        self.cluster.data[self.charm.unit].update({"csr": csr.decode("utf-8").strip()})
+        self.charm.unit_peer_data.update({"csr": csr.decode("utf-8").strip()})
 
         self.certificates.request_certificate_creation(certificate_signing_request=csr)
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import socket
 import subprocess
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from charms.tls_certificates_interface.v1.tls_certificates import (
     CertificateAvailableEvent,
@@ -22,6 +22,9 @@ from ops.charm import ActionEvent, RelationCreatedEvent, RelationJoinedEvent
 from ops.framework import Object
 from ops.model import Unit
 from utils import generate_password, safe_write_to_file
+
+if TYPE_CHECKING:
+    from charm import ZooKeeperCharm
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +38,7 @@ class ZooKeeperTLS(Object):
 
     def __init__(self, charm):
         super().__init__(charm, "tls")
-        self.charm = charm
+        self.charm: "ZooKeeperCharm" = charm
         self.config_path = self.charm.snap.conf_path
         self.certificates = TLSCertificatesRequiresV1(self.charm, "certificates")
 
@@ -138,7 +141,10 @@ class ZooKeeperTLS(Object):
         Returns:
             True if the cluster is running `portUnification`. Otherwise False
         """
-        if self.charm.cluster.relation.data[unit].get("unified"):
+        if not self.charm.peer_relation:
+            return False
+
+        if self.charm.peer_relation.data[unit].get("unified"):
             return True
 
         return False

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -34,24 +34,24 @@ def harness():
 
 def test_peer_units_contains_unit(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
 
     assert len(harness.charm.cluster.peer_units) == 2
 
 
 def test_started_units_ignores_ready_units(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"state": "ready"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"state": "ready"}
         )
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/2")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"state": "started"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/2", {"state": "started"}
         )
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/3")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/3", {"state": "started"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/3", {"state": "started"}
         )
 
     assert len(harness.charm.cluster.started_units) == 2
@@ -69,7 +69,7 @@ def test_get_unit_from_id_succeeds(harness):
 
 def test_get_unit_from_id_raises(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
 
     with pytest.raises(UnitNotFoundError):
         harness.charm.cluster.get_unit_from_id(100)
@@ -77,7 +77,7 @@ def test_get_unit_from_id_raises(harness):
 
 def test_unit_config_raises_for_missing_unit(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
 
     with pytest.raises(UnitNotFoundError):
         harness.charm.cluster.get_unit_from_id(100)
@@ -85,9 +85,9 @@ def test_unit_config_raises_for_missing_unit(harness):
 
 def test_unit_config_succeeds_for_id(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"private-address": "treebeard"}
         )
 
     harness.charm.cluster.unit_config(unit=1)
@@ -96,7 +96,7 @@ def test_unit_config_succeeds_for_id(harness):
 def test_unit_config_succeeds_for_unit(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
 
     harness.charm.cluster.unit_config(harness.charm.unit)
@@ -105,7 +105,7 @@ def test_unit_config_succeeds_for_unit(harness):
 def test_unit_config_has_all_keys(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
 
     config = harness.charm.cluster.unit_config(0)
@@ -123,7 +123,7 @@ def test_unit_config_has_all_keys(harness):
 def test_unit_config_server_string_format(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
 
     server_string = harness.charm.cluster.unit_config(0)["server_string"]
@@ -151,13 +151,13 @@ def test_get_updated_servers(harness):
 def test_is_unit_turn_succeeds_scaleup(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}",
             {"0": "added", "1": "added", "2": "added"},
         )
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/0")
 
-    units = sorted(harness.charm.cluster.relation.units, key=lambda x: x.name)
+    units = sorted(harness.charm.peer_relation.units, key=lambda x: x.name)
     harness.set_planned_units(1)
 
     assert harness.charm.cluster.is_unit_turn(units[0])
@@ -166,16 +166,16 @@ def test_is_unit_turn_succeeds_scaleup(harness):
 def test_is_unit_turn_fails_scaleup(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}",
             {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
         )
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/3")
 
-    units = sorted(harness.charm.cluster.relation.units, key=lambda x: x.name)
+    units = sorted(harness.charm.peer_relation.units, key=lambda x: x.name)
     harness.set_planned_units(4)
 
     assert not harness.charm.cluster.is_unit_turn(units[3])
@@ -184,16 +184,16 @@ def test_is_unit_turn_fails_scaleup(harness):
 def test_is_unit_turn_succeeds_failover(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}",
             {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
         )
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/3")
 
-    units = sorted(harness.charm.cluster.relation.units, key=lambda x: x.name)
+    units = sorted(harness.charm.peer_relation.units, key=lambda x: x.name)
     harness.set_planned_units(4)
 
     assert harness.charm.cluster.is_unit_turn(units[0])
@@ -204,16 +204,16 @@ def test_is_unit_turn_succeeds_failover(harness):
 def test_is_unit_turn_fails_failover(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}",
             {"0": "added", "1": "added", "sync_password": "gollum", "super_password": "precious"},
         )
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/0")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/3")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/0")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/3")
 
-    units = sorted(harness.charm.cluster.relation.units, key=lambda x: x.name)
+    units = sorted(harness.charm.peer_relation.units, key=lambda x: x.name)
     harness.set_planned_units(4)
 
     assert not harness.charm.cluster.is_unit_turn(units[3])
@@ -221,19 +221,19 @@ def test_is_unit_turn_fails_failover(harness):
 
 def test_generate_units_scaleup_adds_all_servers(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/2")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "added"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}", {"0": "added", "1": "added"}
         )
 
     new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
@@ -247,19 +247,19 @@ def test_generate_units_scaleup_adds_all_servers(harness):
 
 def test_generate_units_scaleup_adds_correct_roles_for_added_units(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/2")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/2", {"private-address": "gimli"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}", {"0": "added", "1": "removed"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}", {"0": "added", "1": "removed"}
         )
 
         new_unit_string = harness.charm.cluster.unit_config(2, state="ready", role="observer")[
@@ -273,16 +273,16 @@ def test_generate_units_scaleup_adds_correct_roles_for_added_units(harness):
 
 def test_generate_units_failover(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/2")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}",
             {"0": "removed", "1": "added", "2": "removed"},
         )
@@ -297,12 +297,12 @@ def test_generate_units_failover(harness):
 
 def test_startup_servers_raises_for_missing_data(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/2")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}",
             {"0": "removed", "sync_password": "Mellon"},
         )
@@ -314,10 +314,10 @@ def test_startup_servers_raises_for_missing_data(harness):
 def test_startup_servers_succeeds_init(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}",
             {"sync_password": "gollum", "super_password": "precious"},
         )
@@ -330,15 +330,15 @@ def test_startup_servers_succeeds_init(harness):
 
 def test_startup_servers_succeeds_failover_after_init(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"private-address": "treebeard"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"private-address": "gandalf"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}",
             {"0": "removed", "1": "added", "sync_password": "Mellon"},
         )
@@ -353,7 +353,7 @@ def test_all_units_related(harness):
     with harness.hooks_disabled():
         assert not harness.charm.cluster.all_units_related
 
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.set_planned_units(2)
 
         assert harness.charm.cluster.all_units_related
@@ -365,7 +365,7 @@ def test_lowest_unit_id_none_if_not_all_related(harness):
 
 def test_lowest_unit_id(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
 
     harness.set_planned_units(2)
 
@@ -379,7 +379,7 @@ def test_stale_quorum_not_all_related(harness):
 def test_stale_quorum_unit_departed(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": "removed"}
+            harness.charm.peer_relation.id, CHARM_KEY, {"0": "added", "1": "removed"}
         )
 
     assert not harness.charm.cluster.stale_quorum
@@ -387,10 +387,10 @@ def test_stale_quorum_unit_departed(harness):
 
 def test_stale_quorum_new_unit(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.set_planned_units(2)
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": ""}
+            harness.charm.peer_relation.id, CHARM_KEY, {"0": "added", "1": ""}
         )
 
     assert harness.charm.cluster.stale_quorum
@@ -398,10 +398,10 @@ def test_stale_quorum_new_unit(harness):
 
 def test_stale_quorum_all_added(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.set_planned_units(2)
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, CHARM_KEY, {"0": "added", "1": "added"}
+            harness.charm.peer_relation.id, CHARM_KEY, {"0": "added", "1": "added"}
         )
 
     assert not harness.charm.cluster.stale_quorum
@@ -409,9 +409,9 @@ def test_stale_quorum_all_added(harness):
 
 def test_all_rotated_fails(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
         )
 
     assert not harness.charm.cluster._all_rotated()
@@ -419,12 +419,12 @@ def test_all_rotated_fails(harness):
 
 def test_all_rotated_succeeds(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"password-rotated": "true"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"password-rotated": "true"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"password-rotated": "true"}
         )
 
     assert harness.charm.cluster._all_rotated()
@@ -432,9 +432,9 @@ def test_all_rotated_succeeds(harness):
 
 def test_passwords_set_fails_missing_unit_passwords(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}/0",
             {"super-password": "mellon", "sync-password": "mellon"},
         )
@@ -445,7 +445,7 @@ def test_passwords_set_fails_missing_unit_passwords(harness):
 def test_passwords_set_fails_missing_password(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"super-password": "mellon"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"super-password": "mellon"}
         )
 
     assert not harness.charm.cluster.passwords_set
@@ -454,7 +454,7 @@ def test_passwords_set_fails_missing_password(harness):
 def test_passwords_set_succeeds(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}/0",
             {"super-password": "mellon", "sync-password": "mellon"},
         )
@@ -464,34 +464,30 @@ def test_passwords_set_succeeds(harness):
 
 def test_all_units_quorum_fails_wrong_quorum(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"quorum": "non-ssl"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"quorum": "non-ssl"}
         )
 
         assert not harness.charm.cluster.all_units_quorum
 
-        harness.update_relation_data(
-            harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"}
-        )
+        harness.update_relation_data(harness.charm.peer_relation.id, CHARM_KEY, {"quorum": "ssl"})
 
         assert not harness.charm.cluster.all_units_quorum
 
 
 def test_all_units_quorum_succeeds(harness):
     with harness.hooks_disabled():
-        harness.add_relation_unit(harness.charm.cluster.relation.id, f"{CHARM_KEY}/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, f"{CHARM_KEY}/1")
+        harness.update_relation_data(harness.charm.peer_relation.id, CHARM_KEY, {"quorum": "ssl"})
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, CHARM_KEY, {"quorum": "ssl"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/1", {"quorum": "ssl"}
-        )
-        harness.update_relation_data(
-            harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"quorum": "ssl"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"quorum": "ssl"}
         )
 
     assert harness.charm.cluster.all_units_quorum

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -60,7 +60,7 @@ def test_jaas_users_are_added(harness):
             harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
         harness.update_relation_data(
-            harness.charm.provider.app_relation.id, CHARM_KEY, {"relation-2": "password"}
+            harness.charm.peer_relation.id, CHARM_KEY, {"relation-2": "password"}
         )
 
     assert len(harness.charm.zookeeper_config.jaas_users) == 1
@@ -77,7 +77,7 @@ def test_multiple_jaas_users_are_added(harness):
             harness.charm.provider.client_relations[1].id, "application2", {"chroot": "app2"}
         )
         harness.update_relation_data(
-            harness.charm.provider.app_relation.id,
+            harness.charm.peer_relation.id,
             CHARM_KEY,
             {"relation-2": "password", "relation-3": "password"},
         )
@@ -87,7 +87,7 @@ def test_multiple_jaas_users_are_added(harness):
 
 def test_tls_enabled(harness):
     with harness.hooks_disabled():
-        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
+        harness.update_relation_data(harness.charm.peer_relation.id, CHARM_KEY, {"tls": "enabled"})
 
     assert "ssl.clientAuth=none" in harness.charm.zookeeper_config.zookeeper_properties
 
@@ -99,24 +99,24 @@ def test_tls_disabled(harness):
 def test_tls_upgrading(harness):
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.tls.cluster.id, CHARM_KEY, {"upgrading": "started"}
+            harness.charm.peer_relation.id, CHARM_KEY, {"upgrading": "started"}
         )
 
         assert "portUnification=true" in harness.charm.zookeeper_config.zookeeper_properties
 
-        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"upgrading": ""})
+        harness.update_relation_data(harness.charm.peer_relation.id, CHARM_KEY, {"upgrading": ""})
 
         assert "portUnification=true" not in harness.charm.zookeeper_config.zookeeper_properties
 
 
 def test_tls_ssl_quorum(harness):
     with harness.hooks_disabled():
-        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"quorum": "ssl"})
+        harness.update_relation_data(harness.charm.peer_relation.id, CHARM_KEY, {"quorum": "ssl"})
 
         assert "sslQuorum=true" in harness.charm.zookeeper_config.zookeeper_properties
 
         harness.update_relation_data(
-            harness.charm.tls.cluster.id, CHARM_KEY, {"quorum": "non-ssl"}
+            harness.charm.peer_relation.id, CHARM_KEY, {"quorum": "non-ssl"}
         )
 
         assert "sslQuorum=true" not in harness.charm.zookeeper_config.zookeeper_properties
@@ -124,9 +124,9 @@ def test_tls_ssl_quorum(harness):
 
 def test_properties_tls_uses_passwords(harness):
     with harness.hooks_disabled():
-        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
+        harness.update_relation_data(harness.charm.peer_relation.id, CHARM_KEY, {"tls": "enabled"})
         harness.update_relation_data(
-            harness.charm.tls.cluster.id, f"{CHARM_KEY}/0", {"keystore-password": "mellon"}
+            harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"keystore-password": "mellon"}
         )
 
     assert "ssl.keyStore.password=mellon" in harness.charm.zookeeper_config.zookeeper_properties
@@ -135,7 +135,7 @@ def test_properties_tls_uses_passwords(harness):
 
 def test_properties_tls_gets_dynamic_config_file_property(harness):
     with harness.hooks_disabled():
-        harness.update_relation_data(harness.charm.tls.cluster.id, CHARM_KEY, {"tls": "enabled"})
+        harness.update_relation_data(harness.charm.peer_relation.id, CHARM_KEY, {"tls": "enabled"})
 
     with open("/tmp/zoo.cfg", "w") as fp:
         fp.write("dynamicConfigFile=/gandalf/the/grey")

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -50,7 +50,7 @@ def test_relation_config_new_relation(harness):
             harness.charm.provider.client_relations[0].id, "application", {"chroot": "app"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, REL_NAME, {"relation-0": "password"}
+            harness.charm.peer_relation.id, REL_NAME, {"relation-0": "password"}
         )
 
         config = harness.charm.provider.relation_config(
@@ -72,7 +72,7 @@ def test_relation_config_new_relation_defaults_to_database(harness):
             harness.charm.provider.client_relations[0].id, "application", {"database": "app"}
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id, REL_NAME, {"relation-0": "password"}
+            harness.charm.peer_relation.id, REL_NAME, {"relation-0": "password"}
         )
 
         config = harness.charm.provider.relation_config(
@@ -238,12 +238,12 @@ def test_port_updates_if_tls(harness):
 
         # checking if ssl port and ssl flag are passed
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             "zookeeper/0",
             {"private-address": "treebeard", "state": "started"},
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             REL_NAME,
             {"quorum": "ssl", "relation-0": "mellon"},
         )
@@ -259,12 +259,12 @@ def test_port_updates_if_tls(harness):
     with harness.hooks_disabled():
         # checking if normal port and non-ssl flag are passed
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             "zookeeper/0",
             {"private-address": "treebeard", "state": "started", "quorum": "non-ssl"},
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             REL_NAME,
             {"quorum": "non-ssl", "relation-0": "mellon"},
         )
@@ -287,7 +287,7 @@ def test_provider_relation_data_updates_port_if_stable_and_ready(harness):
     ):
         harness.set_leader(True)
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             REL_NAME,
             {"quorum": "non-ssl"},
         )
@@ -308,24 +308,24 @@ def test_apply_relation_data(harness):
             {"chroot": "new_app", "chroot-acl": "rw"},
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             "zookeeper/0",
             {"private-address": "treebeard", "state": "started"},
         )
-        harness.add_relation_unit(harness.charm.cluster.relation.id, "zookeeper/1")
+        harness.add_relation_unit(harness.charm.peer_relation.id, "zookeeper/1")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             "zookeeper/1",
             {"private-address": "shelob", "state": "ready"},
         )
-        harness.add_relation_unit(harness.charm.cluster.relation.id, "zookeeper/2")
+        harness.add_relation_unit(harness.charm.peer_relation.id, "zookeeper/2")
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             "zookeeper/2",
             {"private-address": "balrog", "state": "started"},
         )
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             "zookeeper",
             {"relation-0": "mellon", "relation-3": "friend"},
         )
@@ -337,10 +337,10 @@ def test_apply_relation_data(harness):
     ):
         harness.charm.provider.apply_relation_data()
 
-    assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-0", None)
-    assert harness.charm.cluster.relation.data[harness.charm.app].get("relation-3", None)
+    assert harness.charm.app_peer_data.get("relation-0", None)
+    assert harness.charm.app_peer_data.get("relation-3", None)
 
-    app_data = harness.charm.cluster.relation.data[harness.charm.app]
+    app_data = harness.charm.app_peer_data
     passwords = []
     usernames = []
     for relation in harness.charm.provider.client_relations:

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -28,7 +28,7 @@ def harness():
 
 def test_all_units_unified_succeeds(harness):
     harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"unified": "true"}
+        harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"unified": "true"}
     )
     harness.set_planned_units(1)
     assert harness.charm.tls.all_units_unified
@@ -124,7 +124,7 @@ def test_certificates_available_succeeds(harness):
     harness.add_relation(harness.charm.restart.name, "{CHARM_KEY}/0")
 
     harness.update_relation_data(
-        harness.charm.cluster.relation.id, f"{CHARM_KEY}/0", {"csr": "not-missing"}
+        harness.charm.peer_relation.id, f"{CHARM_KEY}/0", {"csr": "not-missing"}
     )
 
     # implicitly tests these method calls
@@ -152,7 +152,7 @@ def test_certificates_broken(harness):
         certs_rel_id = harness.add_relation(CERTS_REL_NAME, "tls-certificates-operator")
 
         harness.update_relation_data(
-            harness.charm.cluster.relation.id,
+            harness.charm.peer_relation.id,
             f"{CHARM_KEY}/0",
             {"csr": "not-missing", "certificate": "cert", "ca": "exists"},
         )
@@ -181,7 +181,7 @@ def test_certificates_expiring(harness):
     key = open("tests/keys/0.key").read()
 
     harness.update_relation_data(
-        harness.charm.cluster.relation.id,
+        harness.charm.peer_relation.id,
         f"{CHARM_KEY}/0",
         {"csr": "csr", "private-key": key, "certificate": "cert", "private-address": "1.1.1.1"},
     )


### PR DESCRIPTION
## Changes Made
##### `refactor: add ZooKeeperCharm type hints`
##### `chore: bump python-libjuju ver to 3`
##### `refactor: remove excess peer_relation refs`
- Tracking all the different object specific copies of `peer_relation` was a pain
- Now it's all stuck within `charm.py` and accessed from outside using `self.charm.peer_relation` and `self.charm.app/unit_peer_data`
##### `chore: add more to jujuignore`
- Currently loads of stuff was in there
- Now it should be slightly faster to deploy