### PR TITLE
feat: add snapshot storage

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,11 +34,6 @@ requires:
 storage:
   data:
     type: filesystem
-    description: Directories where the snapshot data is stored
+    description: Directories where snapshot and transaction data is stored
     minimum-size: 10G
-    location: /var/snap/charmed-zookeeper/common/var/lib/zookeeper/data
-  data-log:
-    type: filesystem
-    description: Directories where the transaction log data is stored
-    minimum-size: 10G
-    location: /var/snap/charmed-zookeeper/common/var/lib/zookeeper/data-log
+    location: /var/snap/charmed-zookeeper/common/var/lib/zookeeper

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,3 +30,10 @@ requires:
     interface: tls-certificates
     limit: 1
     optional: true
+
+storage:
+  data:
+    type: filesystem
+    description: Directories where the log data is stored
+    minimum-size: 10G
+    location: /var/snap/charmed-zookeeper/common/var/lib/zookeeper

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,6 +34,11 @@ requires:
 storage:
   data:
     type: filesystem
-    description: Directories where the log data is stored
+    description: Directories where the snapshot data is stored
     minimum-size: 10G
-    location: /var/snap/charmed-zookeeper/common/var/lib/zookeeper
+    location: /var/snap/charmed-zookeeper/common/var/lib/zookeeper/data
+  data-log:
+    type: filesystem
+    description: Directories where the transaction log data is stored
+    minimum-size: 10G
+    location: /var/snap/charmed-zookeeper/common/var/lib/zookeeper/data-log

--- a/src/charm.py
+++ b/src/charm.py
@@ -216,7 +216,7 @@ class ZooKeeperCharm(CharmBase):
         logger.info(f"Server.{self.cluster.get_unit_id(self.unit)} initializing")
 
         # setting default properties
-        self.zookeeper_config.set_zookeeper_myid()
+        self.zookeeper_config.set_zookeeper_data()
         self.zookeeper_config.set_server_jvmflags()
 
         # servers properties needs to be written to dynamic config

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,15 @@ from charms.grafana_agent.v0.cos_agent import COSAgentProvider, Optional, Relati
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from cluster import ZooKeeperCluster
 from config import ZooKeeperConfig
-from literals import CHARM_KEY, CHARM_USERS, JMX_PORT, METRICS_PROVIDER_PORT, PEER
+from literals import (
+    CHARM_KEY,
+    CHARM_USERS,
+    DATA_DIR,
+    DATALOG_DIR,
+    JMX_PORT,
+    METRICS_PROVIDER_PORT,
+    PEER,
+)
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -26,7 +34,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from provider import ZooKeeperProvider
 from snap import ZooKeeperSnap
 from tls import ZooKeeperTLS
-from utils import generate_password, safe_get_file
+from utils import generate_password, safe_get_file, safe_make_dir
 
 logger = logging.getLogger(__name__)
 
@@ -215,8 +223,12 @@ class ZooKeeperCharm(CharmBase):
         self.unit.status = MaintenanceStatus("starting ZooKeeper server")
         logger.info(f"Server.{self.cluster.get_unit_id(self.unit)} initializing")
 
+        # creating necessary dirs + permissions
+        safe_make_dir(path=f"{self.snap.data_path}/{DATA_DIR}")
+        safe_make_dir(path=f"{self.snap.data_path}/{DATALOG_DIR}")
+
         # setting default properties
-        self.zookeeper_config.set_zookeeper_data()
+        self.zookeeper_config.set_zookeeper_myid()
         self.zookeeper_config.set_server_jvmflags()
 
         # servers properties needs to be written to dynamic config

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@
 import logging
 from typing import TYPE_CHECKING, List
 
-from literals import JMX_PORT, METRICS_PROVIDER_PORT, REL_NAME
+from literals import DATA_DIR, DATALOG_DIR, JMX_PORT, METRICS_PROVIDER_PORT, REL_NAME
 from utils import safe_get_file, safe_write_to_file, update_env
 
 if TYPE_CHECKING:
@@ -153,8 +153,8 @@ class ZooKeeperConfig:
             ]
             + DEFAULT_PROPERTIES.split("\n")
             + [
-                f"dataDir={self.charm.snap.data_path}",
-                f"dataLogDir={self.charm.snap.logs_path}",
+                f"dataDir={self.charm.snap.data_path}/{DATA_DIR}",
+                f"dataLogDir={self.charm.snap.data_path}/{DATALOG_DIR}",
                 f"{self.current_dynamic_config_file}",
             ]
             + self.metrics_exporter_config
@@ -257,7 +257,7 @@ class ZooKeeperConfig:
         """Writes ZooKeeper myid file to config/data."""
         safe_write_to_file(
             content=f"{int(self.charm.unit.name.split('/')[1]) + 1}",
-            path=f"{self.charm.snap.data_path}/myid",
+            path=f"{self.charm.snap.data_path}/{DATA_DIR}/myid",
         )
 
     @staticmethod

--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,6 @@
 """Manager for handling ZooKeeper auth configuration."""
 
 import logging
-import os
 from typing import TYPE_CHECKING, List
 
 from literals import DATA_DIR, DATALOG_DIR, JMX_PORT, METRICS_PROVIDER_PORT, REL_NAME
@@ -254,11 +253,8 @@ class ZooKeeperConfig:
         """Writes zookeeper-dynamic.properties containing server connection strings."""
         safe_write_to_file(content=servers, path=self.dynamic_filepath, mode="w")
 
-    def set_zookeeper_data(self) -> None:
-        """Writes ZooKeeper myid file to, and creates necessary data dirs."""
-        os.makedirs(os.path.dirname(f"{self.charm.snap.data_path}/{DATA_DIR}"), exist_ok=True)
-        os.makedirs(os.path.dirname(f"{self.charm.snap.data_path}/{DATALOG_DIR}"), exist_ok=True)
-
+    def set_zookeeper_myid(self) -> None:
+        """Writes ZooKeeper myid file to data dir."""
         safe_write_to_file(
             content=f"{int(self.charm.unit.name.split('/')[1]) + 1}",
             path=f"{self.charm.snap.data_path}/{DATA_DIR}/myid",

--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,7 @@
 """Manager for handling ZooKeeper auth configuration."""
 
 import logging
+import os
 from typing import TYPE_CHECKING, List
 
 from literals import DATA_DIR, DATALOG_DIR, JMX_PORT, METRICS_PROVIDER_PORT, REL_NAME
@@ -253,8 +254,11 @@ class ZooKeeperConfig:
         """Writes zookeeper-dynamic.properties containing server connection strings."""
         safe_write_to_file(content=servers, path=self.dynamic_filepath, mode="w")
 
-    def set_zookeeper_myid(self) -> None:
-        """Writes ZooKeeper myid file to config/data."""
+    def set_zookeeper_data(self) -> None:
+        """Writes ZooKeeper myid file to, and creates necessary data dirs."""
+        os.makedirs(os.path.dirname(f"{self.charm.snap.data_path}/{DATA_DIR}"), exist_ok=True)
+        os.makedirs(os.path.dirname(f"{self.charm.snap.data_path}/{DATALOG_DIR}"), exist_ok=True)
+
         safe_write_to_file(
             content=f"{int(self.charm.unit.name.split('/')[1]) + 1}",
             path=f"{self.charm.snap.data_path}/{DATA_DIR}/myid",

--- a/src/literals.py
+++ b/src/literals.py
@@ -14,3 +14,6 @@ CHARM_USERS = ["super", "sync"]
 CERTS_REL_NAME = "certificates"
 JMX_PORT = 9998
 METRICS_PROVIDER_PORT = 7000
+
+DATA_DIR = "data"
+DATALOG_DIR = "data-log"

--- a/src/utils.py
+++ b/src/utils.py
@@ -14,6 +14,16 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 
+def safe_make_dir(path: str) -> None:
+    """Ensures destination directory.
+
+    Args:
+        path: the full directory filepath to create
+    """
+    os.makedirs(path, exist_ok=True)
+    shutil.chown(path, user="snap_daemon", group="root")
+
+
 def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
     """Ensures destination filepath exists before writing.
 
@@ -22,7 +32,7 @@ def safe_write_to_file(content: str, path: str, mode: str = "w") -> None:
         path: the full destination filepath
         mode: the write mode. Usually "w" for write, or "a" for append. Default "w"
     """
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    safe_make_dir(path=os.path.dirname(path))
     with open(path, mode) as f:
         f.write(content)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -399,7 +399,7 @@ def test_init_server_calls_necessary_methods(harness):
         )
     with (
         patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=True),
-        patch("config.ZooKeeperConfig.set_zookeeper_data") as zookeeper_data,
+        patch("config.ZooKeeperConfig.set_zookeeper_myid") as zookeeper_myid,
         patch("config.ZooKeeperConfig.set_server_jvmflags") as server_jvmflags,
         patch(
             "config.ZooKeeperConfig.set_zookeeper_dynamic_properties"
@@ -407,16 +407,18 @@ def test_init_server_calls_necessary_methods(harness):
         patch("config.ZooKeeperConfig.set_zookeeper_properties") as zookeeper_properties,
         patch("config.ZooKeeperConfig.set_jaas_config") as zookeeper_jaas_config,
         patch("snap.ZooKeeperSnap.start_snap_service") as start,
+        patch("charm.safe_make_dir") as safe_make_dir,
     ):
         harness.charm.init_server()
 
-        zookeeper_data.assert_called_once()
+        zookeeper_myid.assert_called_once()
         server_jvmflags.assert_called_once()
         zookeeper_dynamic_properties.assert_called_once()
         zookeeper_properties.assert_called_once()
         zookeeper_jaas_config.assert_called_once()
         start.assert_called_once()
 
+        assert safe_make_dir.call_count == 2
         assert harness.charm.unit_peer_data.get("quorum", None) == "ssl"
         assert harness.charm.unit_peer_data.get("unified", None) == "true"
         assert harness.charm.unit_peer_data.get("state", None) == "started"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -399,7 +399,7 @@ def test_init_server_calls_necessary_methods(harness):
         )
     with (
         patch("cluster.ZooKeeperCluster.is_unit_turn", return_value=True),
-        patch("config.ZooKeeperConfig.set_zookeeper_myid") as zookeeper_myid,
+        patch("config.ZooKeeperConfig.set_zookeeper_data") as zookeeper_data,
         patch("config.ZooKeeperConfig.set_server_jvmflags") as server_jvmflags,
         patch(
             "config.ZooKeeperConfig.set_zookeeper_dynamic_properties"
@@ -410,7 +410,7 @@ def test_init_server_calls_necessary_methods(harness):
     ):
         harness.charm.init_server()
 
-        zookeeper_myid.assert_called_once()
+        zookeeper_data.assert_called_once()
         server_jvmflags.assert_called_once()
         zookeeper_dynamic_properties.assert_called_once()
         zookeeper_properties.assert_called_once()


### PR DESCRIPTION
## Changes Made
##### `feat: add separate storage for transaction log data vs snapshot data`
- Following recommendations found under `dataLogDir` from the [ZooKeeper Administration Guide](https://zookeeper.apache.org/doc/r3.1.2/zookeeperAdmin.html#sc_advancedConfiguration)
- Intent is to have a persistent storage source for all necessary back-up data