### PR TITLE
[DPE-2010] Alerting rules for Zookeeper VM

### DIFF
--- a/src/alert_rules/prometheus/high_file_descriptors.rule
+++ b/src/alert_rules/prometheus/high_file_descriptors.rule
@@ -1,7 +1,0 @@
-alert: ZookeeperHighFileDescriptors
-expr: (open_file_descriptor_count / max_file_descriptor_count)  > 0.7
-for: 10m
-labels:
-  severity: warning
-annotations:
-  summary: "Number of file descriptors used over the limit."

--- a/src/alert_rules/prometheus/jmx_missing.rule
+++ b/src/alert_rules/prometheus/jmx_missing.rule
@@ -1,8 +1,0 @@
-alert: ZooKeeperMissing
-expr: up == 0
-for: 0m
-labels:
-  severity: critical
-annotations:
-  summary: Prometheus target missing (instance {{ $labels.instance }})
-  description: "ZooKeeper target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/src/alert_rules/prometheus/jvm_filling.rule
+++ b/src/alert_rules/prometheus/jvm_filling.rule
@@ -1,8 +1,0 @@
-alert: JvmMemoryFillingUp
-expr: (sum by (instance)(jvm_memory_bytes_used{area="heap"}) / sum by (instance)(jvm_memory_bytes_max{area="heap"})) * 100 > 80
-for: 2m
-labels:
-  severity: warning
-annotations:
-  summary: JVM memory filling up (instance {{ $labels.instance }})
-  description: "JVM memory is filling up (> 80%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/src/alert_rules/prometheus/outstanding_requests.rule
+++ b/src/alert_rules/prometheus/outstanding_requests.rule
@@ -1,7 +1,0 @@
-alert: ZookeeperOutstandingRequests
-expr: outstanding_requests > 10
-for: 10m
-labels:
-  severity: high
-annotations:
-  summary: "Zookeeper receives more requests than it can process."

--- a/src/alert_rules/prometheus/zk_avg_lantecy.rule
+++ b/src/alert_rules/prometheus/zk_avg_lantecy.rule
@@ -1,7 +1,0 @@
-alert: ZookeeperHighLatency
-expr: avg_latency > 500
-for: 15m
-labels:
-  severity: warning
-annotations:
-  summary: "Average amount of time it takes for the server to respond to each client request (since the server was started)."

--- a/src/alert_rules/prometheus/zookeeper_metrics.rules
+++ b/src/alert_rules/prometheus/zookeeper_metrics.rules
@@ -1,0 +1,174 @@
+groups:
+- name: zookeeper.alerts
+  rules:
+  # ==============
+  # Base JMX Rules
+  # ==============
+  - alert: ZooKeeper Missing
+    expr: up{juju_charm!=".*"} == 0
+    for: 0m
+    labels:
+      severity: critical
+    annotations:
+      summary: Prometheus target missing (instance {{ $labels.instance }})
+      description: "ZooKeeper target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+  - alert: JvmMemory Filling Up
+    expr: (sum by (instance)(jvm_memory_bytes_used{area="heap",juju_charm!=".*"}) / sum by (instance)(jvm_memory_bytes_max{area="heap",juju_charm!=".*"})) * 100 > 80
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: JVM memory filling up (instance {{ $labels.instance }})
+      description: "JVM memory is filling up (> 80%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+  - alert: Zookeeper Threads Dead Locked
+    expr: jvm_threads_deadlocked{juju_charm!=".*"} > 0
+    labels:
+      severity: warning
+    annotations:
+      summary: "Zookeeper JVM threads Deadlock occurred."
+      description: |-
+        JVM Thread Deadlock means a situation where two or more JVM threads are blocked forever, waiting for each other.
+        Deadlock occurs when multiple threads need the same locks but obtain them in different order.
+
+        Also look to JVM documentation about threads state:
+        https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Thread.State.html
+
+  # ===============
+  # Zookeeper Usage
+  # ===============
+  - alert: Too Many Znodes
+    expr: znode_count{juju_charm!=".*"} > 1000000
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.instance }} create too many znodes"
+      description: "{{ $labels.instance }} of job {{$labels.job}} create too many znodes: [{{ $value }}]."
+
+  - alert: Too Many Connections
+    expr: num_alive_connections{juju_charm!=".*"} > 100
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.instance }} create too many connections"
+      description: "{{ $labels.instance }} of job {{$labels.job}} create too many connections: [{{ $value }}]."
+
+  - alert: Znode Total Cccupied Memory Too Big
+    expr: approximate_data_size{juju_charm!=".*"} /1024 /1024 > 1 * 1024 # more than 1024 MB(1 GB)
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.instance }} znode total occupied memory is too big"
+      description: "{{ $labels.instance }} of job {{$labels.job}} znode total occupied memory is too big: [{{ $value }}] MB."
+
+  - alert: Too Many Watch
+    expr: watch_count{juju_charm!=".*"} > 10000
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.instance }} set too many watch"
+      description: "{{ $labels.instance }} of job {{$labels.job}} set too many watch: [{{ $value }}]."
+
+  - alert: Leader Election In Progress
+    expr: increase(election_time_count{juju_charm!=".*"}[5m]) > 0
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.instance }} a leader election happens"
+      description: "{{ $labels.instance }} of job {{$labels.job}} a leader election happens: [{{ $value }}]."
+
+  - alert: Too Long fsync Time
+    expr: rate(fsynctime_sum{juju_charm!=".*"}[2m]) > 100
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.instance }} fsync time is too long"
+      description: "{{ $labels.instance }} of job {{$labels.job}} fsync time is too long: [{{ $value }}]."
+
+  - alert: Too Long snapshot Time
+    expr: rate(snapshottime_sum{juju_charm!=".*"}[5m]) > 100
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.instance }} take snapshot time is too long"
+      description: "{{ $labels.instance }} of job {{$labels.job}} take snapshot time is too long: [{{ $value }}]."
+
+  - alert: Zookeeper Too Many File Descriptors
+    expr: (open_file_descriptor_count{juju_charm!=".*"} / max_file_descriptor_count{juju_charm!=".*"})  > 0.7
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Number of file descriptors used over the limit."
+
+  - alert: Zookeeper Outstanding Requests
+    expr: outstanding_requests{juju_charm!=".*"} > 10
+    for: 10m
+    labels:
+      severity: high
+    annotations:
+      summary: "Zookeeper receives more requests than it can process."
+      description: "Zookeeper is processing more requests that it can process. Too many applications are possibly being connected to Zookeeper."
+
+  - alert: Zookeeper High Latency
+    expr: avg_latency{juju_charm!=".*"} > 500
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Average amount of time it takes for the server to respond to each client request (since the server was started)."
+      description: "Very High Latency can be connected to sloppy performance of the hardware underlying Zookeeper or due to Zookeeper handling too many requests."
+
+  - alert: Zookeeper Pending Syncs
+    expr: pending_syncs{juju_charm!=".*"} > 10
+    for: 5m
+    labels:
+      severity: high
+    annotations:
+      summary: "Possible Zookeeper master pending syncs with followers."
+
+  - alert: Zookeeper Pending Sessions
+    expr: pending_session_queue_size{juju_charm!=".*"} > 10
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Possible Zookeeper pending sessions."
+
+  - alert: Zookeeper Outstanding TLS Handshakes
+    expr: outstanding_tls_handshake{juju_charm!=".*"} > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Zookeeper receives more TLS handshake than it can process."
+
+  - alert: Zookeeper Connection Rejected
+    expr: increase(connection_rejected{juju_charm!=".*"}[2m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Zookeeper reject connection."
+
+  - alert: Zookeeper High Ephemeral Nodes
+    expr: ephemerals_count{juju_charm!=".*"} > 100
+    labels:
+      severity: warning
+    annotations:
+      summary: "Zookeeper have too high ephemeral znodes count."
+
+  - alert: Zookeeper Unrecoverable Errors
+    expr: increase(unrecoverable_error_count{juju_charm!=".*"}[2m]) > 0
+    labels:
+      severity: high
+    annotations:
+      summary: "Zookeeper have unhandled Exception"


### PR DESCRIPTION
# Description

This PR is to provide some sensible defaults for the base alerting rule for Zookeeper

Note: The label `juju_charm!=".*"` in every rule is to workaround a bug currently found in COS, where the `juju_charm` is applied to the rules but not to the metrics. See more details [here](https://github.com/canonical/grafana-agent-k8s-operator/issues/190)