### PR TITLE
Fix invalid etc env (fix #73)

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -79,8 +79,9 @@ def map_env(env: list[str]) -> dict[str, str]:
     for var in env:
         key = "".join(var.split("=", maxsplit=1)[0])
         value = "".join(var.split("=", maxsplit=1)[1:])
-
-        map_env[key] = value
+        if key:
+            # only check for keys, as we can have an empty value for a variable
+            map_env[key] = value
 
     return map_env
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -24,11 +24,12 @@ def test_map_env_populated():
         # checks handles multiple equals signs in value
         assert len(value.split()) == 3
 
+
 def test_map_env_empty_item():
     # we get this after reading the default /etc/environment from a stock 22.04 because of safe_get_file,
     # see: https://github.com/verterok/zookeeper-operator/blob/fix-invalid-etc-env/src/utils.py#L44
     example_env = [
-        "PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\"",
+        'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"',
         "",
     ]
     env = map_env(env=example_env)
@@ -38,6 +39,7 @@ def test_map_env_empty_item():
 
     for value in env.values():
         assert type(value) == str
+
 
 def test_get_env_empty():
     with patch("utils.safe_get_file", return_value=[]):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -24,6 +24,20 @@ def test_map_env_populated():
         # checks handles multiple equals signs in value
         assert len(value.split()) == 3
 
+def test_map_env_empty_item():
+    # we get this after reading the default /etc/environment from a stock 22.04 because of safe_get_file,
+    # see: https://github.com/verterok/zookeeper-operator/blob/fix-invalid-etc-env/src/utils.py#L44
+    example_env = [
+        "PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\"",
+        "",
+    ]
+    env = map_env(env=example_env)
+
+    assert len(env) == 1
+    assert sorted(env.keys()) == sorted(["PATH"])
+
+    for value in env.values():
+        assert type(value) == str
 
 def test_get_env_empty():
     with patch("utils.safe_get_file", return_value=[]):


### PR DESCRIPTION
Ignore empty keys when building the map_env dict