### PR TITLE
Add version getter

### DIFF
--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -74,7 +74,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -424,6 +424,24 @@ class ZooKeeperManager:
             certfile_path=self.certfile_path,
         ) as zk:
             zk.delete_znode(path=path)
+
+    def get_version(self) -> str:
+        """Get ZooKeeper version.
+
+        Version will have a similar format to
+            3.6.4--d65253dcf68e9097c6e95a126463fd5fdeb4521c, built on 12/18/2022 18:10 GMT
+        """
+        with ZooKeeperClient(
+            host=self.leader,
+            client_port=self.client_port,
+            username=self.username,
+            password=self.password,
+            use_ssl=self.use_ssl,
+            keyfile_path=self.keyfile_path,
+            keyfile_password=self.keyfile_password,
+            certfile_path=self.certfile_path,
+        ) as zk:
+            return zk.srvr["Zookeeper version"]
 
 
 class ZooKeeperClient:

--- a/lib/charms/zookeeper/v0/client.py
+++ b/lib/charms/zookeeper/v0/client.py
@@ -318,7 +318,7 @@ class ZooKeeperManager:
                     joining=member, leaving=None, new_members=None, from_config=self.config_version
                 )
 
-    def remove_members(self, members: Iterable[str]):
+    def remove_members(self, members: Iterable[str]) -> None:
         """Removes members from the members' dynamic config.
 
         Raises:
@@ -426,10 +426,10 @@ class ZooKeeperManager:
             zk.delete_znode(path=path)
 
     def get_version(self) -> str:
-        """Get ZooKeeper version.
+        """Get ZooKeeper service version from srvr 4lw.
 
-        Version will have a similar format to
-            3.6.4--d65253dcf68e9097c6e95a126463fd5fdeb4521c, built on 12/18/2022 18:10 GMT
+        Returns:
+            String of ZooKeeper service version
         """
         with ZooKeeperClient(
             host=self.leader,
@@ -441,7 +441,7 @@ class ZooKeeperManager:
             keyfile_password=self.keyfile_password,
             certfile_path=self.certfile_path,
         ) as zk:
-            return zk.srvr["Zookeeper version"]
+            return zk.srvr["Zookeeper version"].split("-", maxsplit=1)[0]
 
 
 class ZooKeeperClient:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -23,7 +23,7 @@ class DummyClient:
         self.follower = follower
         self.syncing = syncing
         self.ready = ready
-        self.SRVR = "Zookeeper version: version\nOutstanding: 0\nMode: leader"
+        self.SRVR = "Zookeeper version: 1.2.3--hash Build\nOutstanding: 0\nMode: leader"
         self.MNTR = "zk_pending_syncs	0.0\nzk_peer_state	leading - broadcast"
 
         if self.follower:
@@ -214,3 +214,14 @@ def test_remove_members_runs_on_leader(_):
             )
             in calls
         )
+
+
+@patch.object(DummyClient, "reconfig")
+def test_get_version(_):
+    with patch("charms.zookeeper.v0.client.KazooClient", return_value=DummyClient()):
+        zk = ZooKeeperManager(hosts=["server"], username="", password="")
+        zk.leader = "leader"
+
+        version = zk.get_version()
+
+    assert version == "1.2.3"


### PR DESCRIPTION
Tied to [DPE-2244](https://warthogs.atlassian.net/browse/DPE-2244)

Adds version getter to `client` lib. This can be used both on the ZooKeeper and Kafka charms to solve dependencies.

[DPE-2244]: https://warthogs.atlassian.net/browse/DPE-2244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ