### PR TITLE
DPE-1965/DPE-2065 - chore: remove openjdk

### DIFF
--- a/src/literals.py
+++ b/src/literals.py
@@ -4,7 +4,7 @@
 
 """Collection of global literals for the ZooKeeper charm."""
 
-CHARMED_ZOOKEEPER_SNAP_REVISION = 7
+CHARMED_ZOOKEEPER_SNAP_REVISION = 21
 
 PEER = "cluster"
 REL_NAME = "zookeeper"

--- a/src/snap.py
+++ b/src/snap.py
@@ -36,7 +36,7 @@ class ZooKeeperSnap:
         """
         try:
             apt.update()
-            apt.add_package(["snapd", "openjdk-17-jre-headless"])
+            apt.add_package(["snapd"])
             cache = snap.SnapCache()
             zookeeper = cache[self.SNAP_NAME]
 

--- a/src/tls.py
+++ b/src/tls.py
@@ -308,7 +308,7 @@ class ZooKeeperTLS(Object):
         """Adds CA to JKS truststore."""
         try:
             subprocess.check_output(
-                f"keytool -import -v -alias ca -file ca.pem -keystore truststore.jks -storepass {self.keystore_password} -noprompt",
+                f"charmed-zookeeper.keytool -import -v -alias ca -file ca.pem -keystore truststore.jks -storepass {self.keystore_password} -noprompt",
                 stderr=subprocess.PIPE,
                 shell=True,
                 universal_newlines=True,

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -25,6 +25,7 @@ async def test_deploy_ssl_quorum(ops_test: OpsTest):
         ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3),
         ops_test.model.deploy(
             "tls-certificates-operator",
+            application_name="tls-certificates-operator",
             channel="beta",
             num_units=1,
             config={"generate-self-signed-certificates": "true", "ca-common-name": "zookeeper"},
@@ -69,6 +70,7 @@ async def test_add_tls_provider_succeeds_after_removal(ops_test: OpsTest):
     await asyncio.gather(
         ops_test.model.deploy(
             "tls-certificates-operator",
+            application_name="tls-certificates-operator",
             channel="beta",
             num_units=1,
             config={"generate-self-signed-certificates": "true", "ca-common-name": "zookeeper"},

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -26,7 +26,7 @@ async def test_deploy_ssl_quorum(ops_test: OpsTest):
         ops_test.model.deploy(
             "tls-certificates-operator",
             application_name="tls-certificates-operator",
-            channel="beta",
+            channel="stable",
             num_units=1,
             config={"generate-self-signed-certificates": "true", "ca-common-name": "zookeeper"},
         ),
@@ -71,7 +71,7 @@ async def test_add_tls_provider_succeeds_after_removal(ops_test: OpsTest):
         ops_test.model.deploy(
             "tls-certificates-operator",
             application_name="tls-certificates-operator",
-            channel="beta",
+            channel="stable",
             num_units=1,
             config={"generate-self-signed-certificates": "true", "ca-common-name": "zookeeper"},
         ),


### PR DESCRIPTION
Depends on https://github.com/canonical/charmed-zookeeper-snap/pull/13
Fixes https://github.com/canonical/zookeeper-operator/issues/69

## Changes Made
#### `chore: remove openjdk-17-jre-headless`
- Was originally installed to use `keytool`
- Now usable through `charmed-zookeeper.keytool`
