### PR TITLE
[DPE-2510] Simplify literals

### DIFF
--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -1,28 +1,27 @@
 import asyncio
 import logging
-from pathlib import Path
 
 import continuous_writes as cw
 import helpers
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 
 @pytest.mark.abort_on_fail
 async def test_deploy_active(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+    await ops_test.model.deploy(charm, application_name=helpers.APP_NAME, num_units=3)
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=3600, idle_period=30, wait_for_exact_units=3
+        apps=[helpers.APP_NAME],
+        status="active",
+        timeout=3600,
+        idle_period=30,
+        wait_for_exact_units=3,
     )
 
-    assert ops_test.model.applications[APP_NAME].status == "active"
+    assert ops_test.model.applications[helpers.APP_NAME].status == "active"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -3,13 +3,12 @@
 # See LICENSE file for licensing details.
 
 import logging
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
 from .helpers import (
+    APP_NAME,
     check_key,
     get_address,
     get_user_password,
@@ -19,9 +18,6 @@ from .helpers import (
 )
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -9,6 +9,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from .helpers import (
+    APP_NAME,
     check_acl_permission,
     check_jaas_config,
     get_application_hosts,
@@ -19,7 +20,6 @@ from .helpers import (
 
 logger = logging.getLogger(__name__)
 
-APP_NAME = "zookeeper"
 DUMMY_NAME_1 = "app"
 DUMMY_NAME_2 = "appii"
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -5,13 +5,12 @@
 import asyncio
 import logging
 import time
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
 from .helpers import (
+    APP_NAME,
     application_active,
     check_key,
     get_password,
@@ -21,9 +20,6 @@ from .helpers import (
 )
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -5,18 +5,13 @@
 import asyncio
 import logging
 import time
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
-from .helpers import check_properties, ping_servers
+from .helpers import APP_NAME, check_properties, ping_servers
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -5,20 +5,16 @@
 import asyncio
 import logging
 import time
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
 from literals import DEPENDENCIES
 
-from .helpers import correct_version_running, get_relation_data, ping_servers
+from .helpers import APP_NAME, correct_version_running, get_relation_data, ping_servers
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 # FIXME: update this to 'stable' when `pre-upgrade-check` is released to 'stable'
 CHANNEL = "edge"


### PR DESCRIPTION
Some simple cleanup to files.
- Use `APP_NAME` that is already instantiated on `helpers.py` file instead of importing `yaml & Path` everywhere.