### PR TITLE
[DPE-2623] chore: fix environment file creation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -99,5 +99,5 @@ def get_env() -> dict[str, str]:
 def update_env(env: dict[str, str]) -> None:
     """Updates /etc/environment file."""
     updated_env = get_env() | env
-    content = "\n".join([f"{key}={value}" for key, value in updated_env.items()])
+    content = "\n".join([f'{key}="{value}"' for key, value in updated_env.items()])
     safe_write_to_file(content=content, path="/etc/environment", mode="w")


### PR DESCRIPTION
`SERVER_JVMFLAGS` value was being created without leading and trailing quotation marks, which would make the value unusable when sourcing the file.
```
/etc/environment
# previously:
SERVER_JVMFLAGS=-Dzookeeper.requireClientAuthScheme=sasl . . .

# now:
SERVER_JVMFLAGS="-Dzookeeper.requireClientAuthScheme=sasl . . . "
```
