### PR TITLE
cicd: keep model in ha test, max-parallel=1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
 
   integration-test:
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix:
         tox-environments:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,7 @@ jobs:
           - integration-provider
           - integration-tls
           - integration-upgrade
+          - integration-replication
     name: ${{ matrix.tox-environments }}
     needs:
       - lint
@@ -96,7 +97,6 @@ jobs:
       matrix:
         tox-environments:
           - integration-ha
-          - integration-replication
     name: ${{ matrix.tox-environments }}
     needs:
       - lint
@@ -130,6 +130,6 @@ jobs:
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
       - name: Run integration tests
-        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --keep-models
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}


### PR DESCRIPTION
## Changes Made
#### `cicd: use max-parralel=1`
- Ensures only one test runs at any time, avoiding CPU limit / timeouts etc
#### `cicd: --keep-model on ha tests`
- Pytest Operator cleanup was challenging after the LXD model was messed with during HA tests
- `--keep-model` allows Github to clean up resources after test completion