### PR TITLE
[DPE-3599] Add missing tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
+          - integration-charm
           - integration-password-rotation
           - integration-provider
           - integration-tls

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+import requests
+from pytest_operator.plugin import OpsTest
+
+from literals import JMX_PORT, METRICS_PROVIDER_PORT
+
+from .helpers import APP_NAME, count_lines_with, get_address
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_active(ops_test: OpsTest):
+    charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[APP_NAME].units) == 3
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME], status="active", timeout=1000, idle_period=30
+        )
+
+    assert ops_test.model.applications[APP_NAME].status == "active"
+
+
+async def test_exporter_endpoints(ops_test: OpsTest):
+    unit_address = await get_address(ops_test=ops_test)
+    jmx_exporter_url = f"http://{unit_address}:{JMX_PORT}/metrics"
+    jmx_resp = requests.get(jmx_exporter_url)
+
+    metrics_url = f"http://{unit_address}:{METRICS_PROVIDER_PORT}/metrics"
+    metrics_resp = requests.get(metrics_url)
+
+    assert jmx_resp.ok, "jmx port not active"
+    assert metrics_resp.ok, "metrics provider port not active"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.log_level_change
+async def test_log_level_change(ops_test: OpsTest):
+    for unit in ops_test.model.applications[APP_NAME].units:
+        assert (
+            count_lines_with(
+                ops_test.model_full_name,
+                unit.name,
+                "/var/snap/charmed-zookeeper/common/var/log/zookeeper/zookeeper.log",
+                "DEBUG",
+            )
+            == 0
+        )
+
+    await ops_test.model.applications[APP_NAME].set_config({"log-level": "DEBUG"})
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", timeout=1000, idle_period=30
+    )
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        assert (
+            count_lines_with(
+                ops_test.model_full_name,
+                unit.name,
+                "/var/snap/charmed-zookeeper/common/var/log/zookeeper/zookeeper.log",
+                "DEBUG",
+            )
+            > 0
+        )
+
+    await ops_test.model.applications[APP_NAME].set_config({"log-level": "INFO"})
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", timeout=1000, idle_period=30
+    )

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -3,13 +3,12 @@
 # See LICENSE file for licensing details.
 
 import logging
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
 from .helpers import (
+    APP_NAME,
     check_key,
     count_lines_with,
     get_address,
@@ -20,9 +19,6 @@ from .helpers import (
 )
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -10,7 +10,6 @@ from pytest_operator.plugin import OpsTest
 from .helpers import (
     APP_NAME,
     check_key,
-    count_lines_with,
     get_address,
     get_user_password,
     ping_servers,
@@ -36,45 +35,6 @@ async def test_deploy_active(ops_test: OpsTest):
         )
 
     assert ops_test.model.applications[APP_NAME].status == "active"
-
-
-@pytest.mark.abort_on_fail
-@pytest.mark.log_level_change
-async def test_log_level_change(ops_test: OpsTest):
-
-    for unit in ops_test.model.applications[APP_NAME].units:
-        assert (
-            count_lines_with(
-                ops_test.model_full_name,
-                unit.name,
-                "/var/snap/charmed-zookeeper/common/var/log/zookeeper/zookeeper.log",
-                "DEBUG",
-            )
-            == 0
-        )
-
-    await ops_test.model.applications[APP_NAME].set_config({"log-level": "DEBUG"})
-
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=1000, idle_period=30
-    )
-
-    for unit in ops_test.model.applications[APP_NAME].units:
-        assert (
-            count_lines_with(
-                ops_test.model_full_name,
-                unit.name,
-                "/var/snap/charmed-zookeeper/common/var/log/zookeeper/zookeeper.log",
-                "DEBUG",
-            )
-            > 0
-        )
-
-    await ops_test.model.applications[APP_NAME].set_config({"log-level": "INFO"})
-
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=1000, idle_period=30
-    )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -4,18 +4,13 @@
 
 import asyncio
 import logging
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
-from .helpers import check_properties, ping_servers
+from .helpers import APP_NAME, check_properties, ping_servers
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 TLS_NAME = "self-signed-certificates"
 

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -5,20 +5,15 @@
 import asyncio
 import logging
 import time
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
 from literals import DEPENDENCIES
 
-from .helpers import correct_version_running, get_relation_data, ping_servers
+from .helpers import APP_NAME, correct_version_running, get_relation_data, ping_servers
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 # FIXME: update this to 'stable' when `pre-upgrade-check` is released to 'stable'
 CHANNEL = "edge"

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ set_env =
     PYTHONPATH = {tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
     PY_COLORS=1
+    charm: TEST_FILE=test_charm.py
     provider: TEST_FILE=test_provider.py
     password-rotation: TEST_FILE=test_password_rotation.py
     tls: TEST_FILE=test_tls.py
@@ -73,7 +74,7 @@ commands =
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     poetry run coverage report
 
-[testenv:integration-{provider,password-rotation,tls,upgrade,ha,replication}]
+[testenv:integration-{charm,provider,password-rotation,tls,upgrade,ha,replication}]
 description = Run integration tests
 set_env =
     {[testenv]set_env}


### PR DESCRIPTION
Adds missing tests file. Addresses #117
- Testing zookeeper access is done on `test_provider.py`.

Also ports change on pebble layer declaration.