### PR TITLE
[DPE-4201][BUGFIX] `secret-changed` handler shouldn't fail with an exception if a secret has no label

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -215,12 +215,15 @@ class ZooKeeperCharm(CharmBase):
         if not self.state.cluster.relation:
             return
 
-        if event.secret.label == self.state.cluster.data_interface._generate_secret_label(
-            PEER,
-            self.state.cluster.relation.id,
-            "extra",  # type:ignore noqa  -- Changes with the https://github.com/canonical/data-platform-libs/issues/124
-        ):
-            self._on_cluster_relation_changed(event)
+        try:
+            if event.secret.label == self.state.cluster.data_interface._generate_secret_label(
+                PEER,
+                self.state.cluster.relation.id,
+                "extra",  # type:ignore noqa  -- Addressed in https://github.com/canonical/data-platform-libs/issues/124
+            ):
+                self._on_cluster_relation_changed(event)
+        except TypeError:
+            return
 
     def _manual_restart(self, event: EventBase) -> None:
         """Forces a rolling-restart event.


### PR DESCRIPTION
Description copied from the Jira ticket:
There is an exception being raised when a secret without label is triggering a secret-changed event.
Note that not only our own secrets are “haning around”, but secrets coming from libs… For which we have NO guarantee to have a label.
Thus this issue is IMPORTANT.
(Impact should be no more than an exception on the event handler, thought. No missed actions on handler run.)

I copy here the same problem experienced on the opensearch-dashboards charm.

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-opensearch-dashboards-3/charm/./src/charm.py", line 217, in <module>
    main(OpensearchDasboardsCharm)
  File "/var/lib/juju/agents/unit-opensearch-dashboards-3/charm/venv/ops/main.py", line 436, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-opensearch-dashboards-3/charm/venv/ops/main.py", line 144, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-opensearch-dashboards-3/charm/venv/ops/framework.py", line 351, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-opensearch-dashboards-3/charm/venv/ops/framework.py", line 853, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-opensearch-dashboards-3/charm/venv/ops/framework.py", line 942, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-opensearch-dashboards-3/charm/./src/charm.py", line 146, in _on_secret_changed
    if event.secret.label == self.state.cluster.data_interface._generate_secret_label(
  File "/var/lib/juju/agents/unit-opensearch-dashboards-3/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 1893, in _generate_secret_label
    return f"{'.'.join(members)}"
```

Since the issue is on data-platform/data_interfaces side, and that’s where it should be fixed, it’s a temporary security measure that’s to be applied on the charms' side until https://github.com/canonical/data-platform-libs/issues/124  is addressed (it’s on the top of my list now for libs adjustmetns).