### PR TITLE
[DPE-4183] - fix: only handle quorum removal on relation-departed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
       - unit-test
       - build
       - integration-test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,6 +93,50 @@ jobs:
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
 
+  integration-test-scaling:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - integration-scaling
+    name: ${{ matrix.tox-environments }}
+    needs:
+      - lint
+      - unit-test
+      - build
+      - integration-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        # TODO: Replace with custom image on self-hosted runner
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: 3.4/stable
+          bootstrap-options: "--agent-version 3.4.2"
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+      - name: Run integration tests
+        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        env:
+          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+
   integration-test-ha:
     strategy:
       fail-fast: false
@@ -105,6 +149,7 @@ jobs:
       - unit-test
       - build
       - integration-test
+      - integration-test-scaling
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,54 @@ jobs:
     name: Build charms
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v7
 
+  integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - integration-charm
+          - integration-password-rotation
+          - integration-provider
+          - integration-tls
+          - integration-upgrade
+          - integration-replication
+    name: ${{ matrix.tox-environments }}
+    needs:
+      - lint
+      - unit-test
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        # TODO: Replace with custom image on self-hosted runner
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: 3.4/stable
+          bootstrap-options: "--agent-version 3.4.2"
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+      - name: Run integration tests
+        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        env:
+          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+
   integration-test-scaling:
     strategy:
       fail-fast: false
@@ -56,6 +104,7 @@ jobs:
       - lint
       - unit-test
       - build
+      - integration-test
     runs-on: [self-hosted, linux, X64, jammy, xlarge]
     timeout-minutes: 120
     steps:
@@ -99,6 +148,7 @@ jobs:
       - lint
       - unit-test
       - build
+      - integration-test
       - integration-test-scaling
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,54 +45,6 @@ jobs:
     name: Build charms
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v7
 
-  integration-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        tox-environments:
-          - integration-charm
-          - integration-password-rotation
-          - integration-provider
-          - integration-tls
-          - integration-upgrade
-          - integration-replication
-    name: ${{ matrix.tox-environments }}
-    needs:
-      - lint
-      - unit-test
-      - build
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup operator environment
-        # TODO: Replace with custom image on self-hosted runner
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-          juju-channel: 3.4/stable
-          bootstrap-options: "--agent-version 3.4.2"
-      - name: Download packed charm(s)
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.build.outputs.artifact-name }}
-      - name: Select tests
-        id: select-tests
-        run: |
-          if [ "${{ github.event_name }}" == "schedule" ]
-          then
-            echo Running unstable and stable tests
-            echo "mark_expression=" >> $GITHUB_OUTPUT
-          else
-            echo Skipping unstable tests
-            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-          fi
-      - name: Run integration tests
-        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
-        env:
-          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
-
   integration-test-scaling:
     strategy:
       fail-fast: false
@@ -104,8 +56,7 @@ jobs:
       - lint
       - unit-test
       - build
-      - integration-test
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: [self-hosted, linux, X64, jammy, xlarge]
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -148,7 +99,6 @@ jobs:
       - lint
       - unit-test
       - build
-      - integration-test
       - integration-test-scaling
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -42,5 +42,5 @@ storage:
   data:
     type: filesystem
     description: Directories where snapshot and transaction data is stored
-    minimum-size: 10G
+    minimum-size: 1G
     location: /var/snap/charmed-zookeeper/common/var/lib/zookeeper

--- a/src/charm.py
+++ b/src/charm.py
@@ -233,7 +233,7 @@ class ZooKeeperCharm(CharmBase):
         ):
             pass
 
-    def _on_storage_attached(self, event: StorageAttachedEvent) -> None:
+    def _on_storage_attached(self, _: StorageAttachedEvent) -> None:
         """Handler for `storage_attached` events."""
         self.workload.exec(["chmod", "750", f"{self.workload.paths.data_path}"])
         self.workload.exec(["chown", f"{USER}:{GROUP}", f"{self.workload.paths.data_path}"])
@@ -401,7 +401,7 @@ class ZooKeeperCharm(CharmBase):
                 logger.debug("tls disabled - switching to non-ssl")
                 self.state.cluster.update({"quorum": "non-ssl"})
 
-            if self.state.all_units_quorum:
+            if self.state.all_units_same_encryption:
                 logger.debug(
                     "all units running desired encryption - removing switching-encryption"
                 )

--- a/src/charm.py
+++ b/src/charm.py
@@ -238,6 +238,9 @@ class ZooKeeperCharm(CharmBase):
         ):
             pass
 
+        # NOTE: if the leader is also going down, it may miss the event to set {unit.id: removed}
+        # to avoid this, eventual clean up occurs during update-status calling update_quorum
+
     def _on_storage_attached(self, _: StorageAttachedEvent) -> None:
         """Handler for `storage_attached` events."""
         self.workload.exec(["chmod", "750", f"{self.workload.paths.data_path}"])

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,10 +9,11 @@ import time
 
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
+from charms.zookeeper.v0.client import QuorumLeaderNotFoundError
+from kazoo.exceptions import BadVersionError, ReconfigInProcessError
 from ops.charm import (
     CharmBase,
     InstallEvent,
-    LeaderElectedEvent,
     RelationDepartedEvent,
     SecretChangedEvent,
     StorageAttachedEvent,
@@ -115,7 +116,7 @@ class ZooKeeperCharm(CharmBase):
             getattr(self.on, "cluster_relation_joined"), self._on_cluster_relation_changed
         )
         self.framework.observe(
-            getattr(self.on, "cluster_relation_departed"), self._on_cluster_relation_changed
+            getattr(self.on, "cluster_relation_departed"), self._on_cluster_relation_departed
         )
 
         self.framework.observe(
@@ -183,10 +184,6 @@ class ZooKeeperCharm(CharmBase):
         # even if leader has not started, attempt update quorum
         self.update_quorum(event=event)
 
-        # don't delay scale-down leader ops by restarting dying unit
-        if getattr(event, "departing_unit", None) == self.unit:
-            return
-
         # check whether restart is needed for all `*_changed` events
         # only restart where necessary to avoid slowdowns
         # config_changed call here implicitly updates jaas + zoo.cfg
@@ -213,6 +210,28 @@ class ZooKeeperCharm(CharmBase):
             return
 
         self._set_status(Status.ACTIVE)
+
+    def _on_cluster_relation_departed(self, event: RelationDepartedEvent) -> None:
+        """Handler for `relation_departed` events."""
+        # is related to issue found in https://bugs.launchpad.net/juju/+bug/2053055
+        # likely due to a controller upgrade or a cloud maintenance with machines being reshuffled
+        # periodically, juju would emit a LeaderElected event, and would return no peer units
+        # the leader would then remove all other units from the quorum, which when restarted, would fail
+        if not event.departing_unit:
+            return
+
+        departing_server_id = (
+            int(event.departing_unit.name.split("/")[1]) + 1
+        )  # server-ids must be positive integers
+
+        try:
+            self.quorum_manager.client.remove_members(members=[f"server.{departing_server_id}"])
+        except (
+            ReconfigInProcessError,  # another unit already handling
+            BadVersionError,  # another unit handled
+            QuorumLeaderNotFoundError,  # this unit is departing, can't find leader in peer data
+        ):
+            pass
 
     def _on_storage_attached(self, event: StorageAttachedEvent) -> None:
         """Handler for `storage_attached` events."""
@@ -356,10 +375,6 @@ class ZooKeeperCharm(CharmBase):
 
         if (
             self.state.stale_quorum  # in the case of scale-up
-            or isinstance(  # to run without delay to maintain quorum on scale down
-                event,
-                (RelationDepartedEvent, LeaderElectedEvent),
-            )
             or self.state.healthy  # to ensure run on update-status
         ):
             updated_servers = self.quorum_manager.update_cluster()

--- a/src/charm.py
+++ b/src/charm.py
@@ -209,6 +209,11 @@ class ZooKeeperCharm(CharmBase):
             self._set_status(Status.SERVICE_UNHEALTHY)
             return
 
+        # in case server was erroneously removed from the quorum
+        if not self.state.stale_quorum and not self.quorum_manager.server_in_quorum:
+            self._set_status(Status.SERVICE_NOT_QUORUM)
+            return
+
         self._set_status(Status.ACTIVE)
 
     def _on_cluster_relation_departed(self, event: RelationDepartedEvent) -> None:

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -315,7 +315,7 @@ class ClusterState(Object):
         return True
 
     @property
-    def all_units_quorum(self) -> bool:
+    def all_units_same_encryption(self) -> bool:
         """Flag to check if all units are using the same quorum encryption."""
         if not self.cluster:
             return False
@@ -369,7 +369,7 @@ class ClusterState(Object):
     @property
     def ready(self) -> Status:
         """Gets appropriate Status if the charm is ready to handle related applications."""
-        if not self.all_units_quorum:
+        if not self.all_units_same_encryption:
             return Status.NOT_ALL_QUORUM
 
         if self.cluster.switching_encryption:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -191,7 +191,6 @@ class ZKCluster(RelationState):
         substrate: SUBSTRATES,
     ):
         super().__init__(relation, data_interface, component, substrate)
-        # Lint :-/ It can't resolve the subtype otherwise, even though the same assignment happens in super()
         self.data_interface = data_interface
         self.app = component
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -68,6 +68,7 @@ class Status(Enum):
         BlockedStatus("unable to install zookeeper service"), "ERROR"
     )
     SERVICE_NOT_RUNNING = StatusLevel(BlockedStatus("zookeeper service not running"), "ERROR")
+    SERVICE_NOT_QUORUM = StatusLevel(BlockedStatus("unit not in the zookeeper quorum"), "ERROR")
     CONTAINER_NOT_CONNECTED = StatusLevel(
         MaintenanceStatus("zookeeper container not ready"), "DEBUG"
     )

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -113,7 +113,7 @@ class QuorumManager:
 
         # settings units to removed that were handled in relation-departed
         # also set here in case leader missed the event
-        for added_id in self.state.cluster.quorum_unit_ids:
+        for added_id in self.state.cluster.added_unit_ids:
             if added_id not in [server.unit_id for server in self.state.servers]:
                 updated_servers[str(added_id)] = "removed"
 

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -22,6 +22,7 @@ from kazoo.security import make_acl
 from ops.charm import RelationEvent
 
 from core.cluster import ClusterState
+from core.models import ZKServer
 from literals import CLIENT_PORT
 
 logger = logging.getLogger(__name__)
@@ -156,6 +157,17 @@ class QuorumManager:
         ) as e:
             logger.warning(str(e))
             return {}
+
+    def server_in_quorum(self, server: ZKServer) -> bool:
+        """Checks if server is in current quorum.
+
+        Args:
+            server: the server to check
+
+        Returns:
+            True if server is found in the quorum. Otherwise False.
+        """
+        return server.server_string in self.client.server_members
 
     @staticmethod
     def _is_child_of(path: str, chroots: Set[str]) -> bool:

--- a/tests/integration/ha/test_scaling.py
+++ b/tests/integration/ha/test_scaling.py
@@ -21,12 +21,11 @@ async def test_deploy_active(ops_test: OpsTest):
         num_units=3,
         storage={"data": {"pool": "lxd-btrfs", "size": 10240}},
     )
+    await helpers.wait_idle(ops_test, units=3)
 
-    # ensures juju leader is one of unit 0, 1, 2
-    # ran before cluster has fully initialised, hence different to below scale-up test
-    await ops_test.model.block_until(
-        lambda: len(ops_test.model.applications[helpers.APP_NAME].units) == 3
-    )
+
+@pytest.mark.abort_on_fail
+async def test_simple_scale_up(ops_test: OpsTest):
     await ops_test.model.applications[helpers.APP_NAME].add_units(count=3)
     await helpers.wait_idle(ops_test, units=6)
 
@@ -38,9 +37,7 @@ async def test_simple_scale_down(ops_test: OpsTest):
     )
     await helpers.wait_idle(ops_test, units=3)
 
-
-@pytest.mark.abort_on_fail
-async def test_simple_scale_up(ops_test: OpsTest):
+    # scaling back up
     await ops_test.model.applications[helpers.APP_NAME].add_units(count=3)
     await helpers.wait_idle(ops_test, units=6)
 

--- a/tests/integration/ha/test_scaling.py
+++ b/tests/integration/ha/test_scaling.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import helpers
+import pytest
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy_active(ops_test: OpsTest):
+    charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(
+        charm,
+        application_name=helpers.APP_NAME,
+        num_units=3,
+        storage={"data": {"pool": "lxd-btrfs", "size": 10240}},
+    )
+
+    # ensures juju leader is one of unit 0, 1, 2
+    # ran before cluster has fully initialised, hence different to below scale-up test
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.applications[helpers.APP_NAME].units) == 3
+    )
+    await ops_test.model.applications[helpers.APP_NAME].add_units(count=3)
+    await helpers.wait_idle(ops_test, units=6)
+
+
+@pytest.mark.abort_on_fail
+async def test_simple_scale_down(ops_test: OpsTest):
+    await ops_test.model.applications[helpers.APP_NAME].destroy_units(
+        f"{helpers.APP_NAME}/5", f"{helpers.APP_NAME}/4", f"{helpers.APP_NAME}/3"
+    )
+    await helpers.wait_idle(ops_test, units=3)
+
+
+@pytest.mark.abort_on_fail
+async def test_simple_scale_up(ops_test: OpsTest):
+    await ops_test.model.applications[helpers.APP_NAME].add_units(count=3)
+    await helpers.wait_idle(ops_test, units=6)
+
+
+@pytest.mark.abort_on_fail
+async def test_complex_scale_down(ops_test: OpsTest):
+    hosts = helpers.get_hosts(ops_test)
+
+    quorum_leader_name = helpers.get_leader_name(ops_test, hosts)
+    charm_leader_name = None
+    other_unit_name = None
+
+    for unit in ops_test.model.applications[helpers.APP_NAME].units:
+        if await unit.is_leader_from_status():
+            charm_leader_name = unit.name
+
+        if unit.name not in [charm_leader_name, quorum_leader_name]:
+            other_unit_name = unit.name
+
+    await ops_test.model.applications[helpers.APP_NAME].destroy_units(
+        quorum_leader_name, charm_leader_name, other_unit_name
+    )
+    await helpers.wait_idle(ops_test, units=3)

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -279,7 +279,7 @@ def test_all_units_unified_succeeds(harness):
     assert harness.charm.state.all_units_unified
 
 
-def test_all_units_quorum_fails_wrong_quorum(harness):
+def test_all_units_same_encryption_fails_wrong_quorum(harness):
     with harness.hooks_disabled():
         harness.add_relation_unit(harness.charm.state.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
@@ -289,16 +289,16 @@ def test_all_units_quorum_fails_wrong_quorum(harness):
             harness.charm.state.peer_relation.id, f"{CHARM_KEY}/0", {"quorum": "non-ssl"}
         )
 
-        assert not harness.charm.state.all_units_quorum
+        assert not harness.charm.state.all_units_same_encryption
 
         harness.update_relation_data(
             harness.charm.state.peer_relation.id, CHARM_KEY, {"quorum": "ssl"}
         )
 
-        assert not harness.charm.state.all_units_quorum
+        assert not harness.charm.state.all_units_same_encryption
 
 
-def test_all_units_quorum_succeeds(harness):
+def test_all_units_same_encryption_succeeds(harness):
     with harness.hooks_disabled():
         harness.add_relation_unit(harness.charm.state.peer_relation.id, f"{CHARM_KEY}/1")
         harness.update_relation_data(
@@ -311,4 +311,4 @@ def test_all_units_quorum_succeeds(harness):
             harness.charm.state.peer_relation.id, f"{CHARM_KEY}/0", {"quorum": "ssl"}
         )
 
-    assert harness.charm.state.all_units_quorum
+    assert harness.charm.state.all_units_same_encryption

--- a/tests/unit/test_quorum.py
+++ b/tests/unit/test_quorum.py
@@ -33,18 +33,20 @@ def harness():
 
 
 def test_get_updated_servers(harness):
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.state.peer_relation.id, f"{CHARM_KEY}/0")
+        harness.update_relation_data(
+            harness.charm.state.peer_relation.id,
+            f"{CHARM_KEY}",
+            {"0": "added", "3": "removed", "4": "added"},
+        )
+
     added_servers = [
         "server.2=gandalf.the.grey",
     ]
-    removed_servers = [
-        "server.2=gandalf.the.grey",
-        "server.3=in.a.hole.in.the.ground.there.lived.a:hobbit",
-    ]
-    updated_servers = harness.charm.quorum_manager._get_updated_servers(
-        add=added_servers, remove=removed_servers
-    )
+    updated_servers = harness.charm.quorum_manager._get_updated_servers(add=added_servers)
 
-    assert updated_servers == {"2": "removed", "1": "added"}
+    assert updated_servers == {"1": "added", "4": "removed"}
 
 
 def test_is_child_of(harness):

--- a/tests/unit/test_quorum.py
+++ b/tests/unit/test_quorum.py
@@ -41,6 +41,9 @@ def test_get_updated_servers(harness):
             {"0": "added", "3": "removed", "4": "added"},
         )
 
+    # at this stage, we have only 1 peer unit-0, and have 'lost' unit-4, which was 'added' but not yet removed
+    # we add unit-1 below, and expect the leader to set unit-1 to 'added', and unit-4 to 'removed'
+
     added_servers = [
         "server.2=gandalf.the.grey",
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ set_env =
     upgrade: TEST_FILE=test_upgrade.py
     ha: TEST_FILE=ha/test_ha.py
     replication: TEST_FILE=ha/test_replication.py
+    scaling: TEST_FILE=ha/test_scaling.py
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
@@ -74,7 +75,7 @@ commands =
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     poetry run coverage report
 
-[testenv:integration-{charm,provider,password-rotation,tls,upgrade,ha,replication}]
+[testenv:integration-{charm,provider,password-rotation,tls,upgrade,ha,replication,scaling}]
 description = Run integration tests
 set_env =
     {[testenv]set_env}


### PR DESCRIPTION
Fixes https://github.com/canonical/zookeeper-operator/issues/140. Probably.

## Changes Made
#### `fix: only handle quorum removal on relation-departed`
- The theory for the bug is that at some point, machines are rotated on the Juju cloud, including the Juju controller machine. When this happens, a unit gets `LeaderElected`, and proceeds to update the quorum. However for whatever reason, it is unable to find any peer units. Thinking they are alone, the new leader promptly removes every other unit from the quorum, without recovery
- The fix ensures that on `relation-departed`, every non-departing unit will attempt to remove the departing unit from the quorum
- This is slightly more resilient against losing Juju or Quorum leaders, as they will be removed in advance of the cluster losing a stable quorum. For additional reading, see the [ZooKeeper docs for `standaloneEnabled`](https://zookeeper.apache.org/doc/r3.5.7/zookeeperReconfig.html#sc_reconfig_standaloneEnabled) which explains why we can scale incrementally down to only 1 unit if necessary
- If the Juju leader isn't departing, it will set `{unit.id: "removed"}` to the peer-data when it receives relation-departing, even if it wasn't the unit that removed it explicitly, assuming another unit handled it
- If the Juju leader IS departing, we might miss the events to set peer-data, but will 'eventually' be cleaned up by the newly elected leader during a reconciliation run of `update-status` --> `update_quorum`
#### `chore: block units not in quorum that should be`
- Just gives a bit more visibility in case the issue arises again
#### `test: add back scaling tests`
- I can't remember why they were removed, probably by me
- Useful to validate that we still can scale past the number of 'failable' units in the quorum - 6 --> 3