### PR TITLE
[DPE-5549] Enable TLS v1.2 for client communication

### DIFF
--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -45,6 +45,7 @@ ssl.trustStore.type=JKS
 ssl.keyStore.type=PKCS12
 sslQuorumReloadCertFiles=true
 client.certReload=true
+ssl.enabledProtocols=TLSv1.3,TLSv1.2
 """
 
 


### PR DESCRIPTION
It seems like our ZooKeeper upgrade to 3.9 changed the default cipher used for encryption.

charmed-zookeeper 3.8:
```
nmap --script ssl-enum-ciphers -p 2182 10.28.199.223
Starting Nmap 7.95 ( https://nmap.org ) at 2024-09-24 10:48 CEST
Nmap scan report for 10.28.199.223
Host is up (0.00012s latency).

PORT     STATE SERVICE
2182/tcp open  cgn-stat
| ssl-enum-ciphers:
|   TLSv1.2:
|     ciphers:
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|     compressors:
|       NULL
|     cipher preference: server
|_  least strength: A

Nmap done: 1 IP address (1 host up) scanned in 0.26 seconds
```

charmed-zookeeper 3.9:
```
nmap --script ssl-enum-ciphers -p 2182 10.28.199.117
Starting Nmap 7.95 ( https://nmap.org ) at 2024-09-24 10:47 CEST
Nmap scan report for 10.28.199.117
Host is up (0.0071s latency).

PORT     STATE SERVICE
2182/tcp open  cgn-stat
| ssl-enum-ciphers:
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|     cipher preference: server
|_  least strength: A

Nmap done: 1 IP address (1 host up) scanned in 0.30 seconds
```

After this PR:

```
nmap --script ssl-enum-ciphers -p 2182 10.28.199.194
Starting Nmap 7.95 ( https://nmap.org ) at 2024-09-24 10:49 CEST
Nmap scan report for 10.28.199.194
Host is up (0.00010s latency).

PORT     STATE SERVICE
2182/tcp open  cgn-stat
| ssl-enum-ciphers:
|   TLSv1.2:
|     ciphers:
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|     compressors:
|       NULL
|     cipher preference: server
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|     cipher preference: server
|_  least strength: A

Nmap done: 1 IP address (1 host up) scanned in 0.64 seconds
```