### PR TITLE
[DPE-5218] Implement restore flow

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -36,3 +36,10 @@ create-backup:
 
 list-backups:
   description: List database backups. S3 credentials are retrieved from a relation with the S3 integrator charm.
+
+restore:
+  description: Restore a database backup. S3 credentials are retrieved from a relation with the S3 integrator charm.
+  params:
+    backup-id:
+      type: string
+      description: A backup-id to identify the backup to restore. Format of <%Y-%m-%dT%H:%M:%SZ>

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,6 +24,8 @@ peers:
     interface: rolling_op
   upgrade:
     interface: upgrade
+  restore:
+    interface: restore
 
 provides:
   zookeeper:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,8 +24,6 @@ peers:
     interface: rolling_op
   upgrade:
     interface: upgrade
-  restore:
-    interface: restore
 
 provides:
   zookeeper:

--- a/src/charm.py
+++ b/src/charm.py
@@ -163,7 +163,7 @@ class ZooKeeperCharm(CharmBase):
             self._set_status(Status.NO_PEER_RELATION)
             return
 
-        if self.state.cluster.id_to_restore:
+        if self.state.cluster.is_restore_in_progress:
             # Ongoing backup restore, we can early return here since the
             # chain of events is only relevant to the backup event handler
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -439,12 +439,7 @@ class ZooKeeperCharm(CharmBase):
             client.update({"endpoints": ""})
 
     def update_client_data(self) -> None:
-        """Writes necessary relation data to all related applications.
-
-        Args:
-            force_update: Add a random value to a field not part of the schema to trigger the
-              relation-changed events on the clients even if the rest of the field stays the same.
-        """
+        """Writes necessary relation data to all related applications."""
         if not self.unit.is_leader():
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -345,6 +345,7 @@ class ZooKeeperCharm(CharmBase):
 
         self.config_manager.set_zookeeper_properties()
         self.config_manager.set_jaas_config()
+        self.config_manager.set_client_jaas_config()
 
         # during reschedules (e.g upgrades or otherwise) we lose all files
         # need to manually add-back key/truststores

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -361,7 +361,7 @@ class ClusterState(Object):
         if self.stale_quorum:
             return Status.STALE_QUORUM
 
-        if self.cluster.id_to_restore:
+        if self.cluster.is_restore_in_progress:
             return Status.ONGOING_RESTORE
 
         if not self.all_servers_added:
@@ -382,3 +382,9 @@ class ClusterState(Object):
             return Status.ALL_UNIFIED
 
         return self.stable
+
+    @property
+    def is_next_restore_step_possible(self) -> bool:
+        """Are all units done with the current restore instruction?"""
+        current_instruction = self.cluster.restore_instruction
+        return all((unit.restore_progress is current_instruction for unit in self.servers))

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -361,6 +361,9 @@ class ClusterState(Object):
         if self.stale_quorum:
             return Status.STALE_QUORUM
 
+        if self.cluster.id_to_restore:
+            return Status.ONGOING_RESTORE
+
         if not self.all_servers_added:
             return Status.NOT_ALL_ADDED
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -299,6 +299,11 @@ class ZKCluster(RelationState):
         """Current restore flow step to go through."""
         return RestoreStep(self.relation_data.get("restore-instruction", ""))
 
+    @property
+    def is_restore_in_progress(self) -> bool:
+        """Is the cluster undergoing a restore?"""
+        return bool(self.id_to_restore)
+
 
 class ZKServer(RelationState):
     """State collection metadata for a charm unit."""

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -13,7 +13,7 @@ from charms.data_platform_libs.v0.data_interfaces import Data, DataPeerData, Dat
 from ops.model import Application, Relation, Unit
 from typing_extensions import deprecated, override
 
-from core.stubs import S3ConnectionInfo
+from core.stubs import RestoreStep, S3ConnectionInfo
 from literals import CHARM_USERS, CLIENT_PORT, ELECTION_PORT, SECRETS_APP, SERVER_PORT
 
 logger = logging.getLogger(__name__)
@@ -289,6 +289,16 @@ class ZKCluster(RelationState):
         # This is checked in events.backup actions
         return json.loads(self.relation_data.get("s3-credentials", "{}"))
 
+    @property
+    def id_to_restore(self) -> str:
+        """Backup id to restore."""
+        return self.relation_data.get("id-to-restore", "")
+
+    @property
+    def restore_instruction(self) -> RestoreStep:
+        """Current restore flow step to go through."""
+        return RestoreStep(self.relation_data.get("restore-instruction", ""))
+
 
 class ZKServer(RelationState):
     """State collection metadata for a charm unit."""
@@ -440,3 +450,8 @@ class ZKServer(RelationState):
             "sans_ip": [self.ip],
             "sans_dns": [self.hostname, self.fqdn],
         }
+
+    @property
+    def restore_progress(self) -> RestoreStep:
+        """Latest restore flow step the unit went through."""
+        return RestoreStep(self.relation_data.get("restore-progress", ""))

--- a/src/core/stubs.py
+++ b/src/core/stubs.py
@@ -3,8 +3,6 @@
 # See LICENSE file for licensing details.
 
 """Types module."""
-from __future__ import annotations
-
 from enum import Enum
 from typing import TypedDict
 
@@ -33,7 +31,7 @@ class RestoreStep(str, Enum):
     RESTART = "restart"
     CLEAN = "clean"
 
-    def next_step(self) -> RestoreStep:
+    def next_step(self) -> "RestoreStep":
         """Get the next logical restore flow step."""
         match self:
             case RestoreStep.NOT_STARTED:

--- a/src/core/stubs.py
+++ b/src/core/stubs.py
@@ -3,6 +3,9 @@
 # See LICENSE file for licensing details.
 
 """Types module."""
+from __future__ import annotations
+
+from enum import Enum
 from typing import TypedDict
 
 S3ConnectionInfo = TypedDict(
@@ -19,3 +22,27 @@ S3ConnectionInfo = TypedDict(
 
 
 BackupMetadata = TypedDict("BackupMetadata", {"id": str, "log-sequence-number": int, "path": str})
+
+
+class RestoreStep(str, Enum):
+    """Represent restore flow step."""
+
+    NOT_STARTED = ""
+    STOP_WORKFLOW = "stop"
+    RESTORE = "restore"
+    RESTART = "restart"
+    CLEAN = "clean"
+
+    def next_step(self) -> RestoreStep:
+        """Get the next logical restore flow step."""
+        match self:
+            case RestoreStep.NOT_STARTED:
+                return RestoreStep.STOP_WORKFLOW
+            case RestoreStep.STOP_WORKFLOW:
+                return RestoreStep.RESTORE
+            case RestoreStep.RESTORE:
+                return RestoreStep.RESTART
+            case RestoreStep.RESTART:
+                return RestoreStep.CLEAN
+            case RestoreStep.CLEAN:
+                return RestoreStep.NOT_STARTED

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -58,6 +58,14 @@ class ZKPaths:
         return f"{self.conf_path}/zookeeper-jaas.cfg"
 
     @property
+    def client_jaas(self) -> str:
+        """The client-jaas.cfg filepath.
+
+        Contains internal user credentials used in SASL auth.
+        """
+        return f"{self.conf_path}/client-jaas.cfg"
+
+    @property
     def jmx_prometheus_javaagent(self) -> str:
         """The JMX exporter JAR filepath.
 

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -3,8 +3,6 @@
 # See LICENSE file for licensing details.
 
 """Event handlers for creating and restoring backups."""
-from __future__ import annotations
-
 import json
 import logging
 from typing import TYPE_CHECKING, cast
@@ -36,7 +34,7 @@ class BackupEvents(Object):
 
     def __init__(self, charm):
         super().__init__(charm, "backup")
-        self.charm: ZooKeeperCharm = charm
+        self.charm: "ZooKeeperCharm" = charm
         self.s3_requirer = S3Requirer(self.charm, S3_REL_NAME)
         self.backup_manager = BackupManager(self.charm.state)
 

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -201,6 +201,7 @@ class BackupEvents(Object):
                 "restore-instruction": RestoreStep.NOT_STARTED.value,
             }
         )
+        event.log(f"Beggining restore flow for snapshot {id_to_restore}")
 
     def _restore_event_dispatch(self, event: RelationEvent):
         cluster_state = self.restore_state.cluster

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -244,7 +244,10 @@ class BackupEvents(Object):
             payload = {"restore-instruction": next_instruction.value}
             if current_instruction is RestoreStep.CLEAN:
                 payload = payload | {"id-to-restore": "", "to_restore": ""}
-                # TODO: notify clients
+                # Update ACLs for already related clients and trigger a relation-changed
+                # on their side
+                self.charm.quorum_manager.update_acls()
+                self.charm.update_client_data(force_update=True)
 
             self.restore_state.cluster.update(payload)
 

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -153,12 +153,13 @@ class BackupEvents(Object):
         """Restore a snapshot referenced by its id.
 
         Steps:
-        - stop client traffic (still necessary if we stops the units?)
+        - stop client traffic
         - stop all units
-        - backup local state so that we can rollback if anything goes wrong (manual op?)
+        - backup local state so that we can rollback if anything goes wrong (manual op)
         - wipe data folders
         - get snapshot from object storage, save in data folder
         - restart units
+        - cleanup leftover files
         - notify clients
         """
         failure_conditions = [

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -236,8 +236,6 @@ class BackupEvents(Object):
             (unit.restore_progress is current_instruction for unit in self.charm.state.servers)
         ):
             payload = {"restore-instruction": next_instruction.value}
-            if current_instruction is RestoreStep.NOT_STARTED:
-                self.charm.disconnect_clients()
             if current_instruction is RestoreStep.CLEAN:
                 payload = payload | {"id-to-restore": "", "to_restore": ""}
                 # Update ACLs for already related clients and trigger a relation-changed

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -5,18 +5,31 @@
 """Event handlers for creating and restoring backups."""
 import json
 import logging
+from enum import Enum
 from typing import TYPE_CHECKING, cast
 
+from charms.data_platform_libs.v0.data_interfaces import (
+    DataPeerData,
+    DataPeerOtherUnitData,
+    DataPeerUnitData,
+)
 from charms.data_platform_libs.v0.s3 import (
     CredentialsChangedEvent,
     CredentialsGoneEvent,
     S3Requirer,
 )
-from ops import ActionEvent
+from ops import (
+    ActionEvent,
+    Application,
+    Relation,
+    RelationEvent,
+    Unit,
+)
 from ops.framework import Object
 
+from core.models import SUBSTRATES, RelationState
 from core.stubs import S3ConnectionInfo
-from literals import S3_BACKUPS_PATH, S3_REL_NAME, Status
+from literals import RESTORE, S3_BACKUPS_PATH, S3_REL_NAME, SUBSTRATE, Status
 from managers.backup import BackupManager
 
 if TYPE_CHECKING:
@@ -31,6 +44,7 @@ class BackupEvents(Object):
     def __init__(self, charm):
         super().__init__(charm, "backup")
         self.charm: "ZooKeeperCharm" = charm
+        self.restore_state = RestoreState(self.charm, substrate=SUBSTRATE)
         self.s3_requirer = S3Requirer(self.charm, S3_REL_NAME)
         self.backup_manager = BackupManager(self.charm.state)
 
@@ -42,6 +56,10 @@ class BackupEvents(Object):
         self.framework.observe(self.charm.on.create_backup_action, self._on_create_backup_action)
         self.framework.observe(self.charm.on.list_backups_action, self._on_list_backups_action)
         self.framework.observe(self.charm.on.restore_action, self._on_restore_action)
+
+        self.framework.observe(
+            getattr(self.charm.on, "restore_relation_changed"), self._restore_event_dispatch
+        )
 
     def _on_s3_credentials_changed(self, event: CredentialsChangedEvent):
         if not self.charm.unit.is_leader():
@@ -140,19 +158,16 @@ class BackupEvents(Object):
         event.set_results({"backups": json.dumps(backups_metadata)})
 
     def _on_restore_action(self, event: ActionEvent):
-        """
-        Steps:
+        """Restore a snapshot referenced by its id.
 
-        - stop client traffic
+        Steps:
+        - stop client traffic (still necessary if we stops the units?)
         - stop all units
-        - backup local state so that we can rollback if anything goes wrong
+        - backup local state so that we can rollback if anything goes wrong (manual op?)
         - wipe data folders
         - get snapshot from object storage, save in data folder
         - restart units
-
-        - everything ok, delete local backup
-        - something wrong, rollback local state by re-using the previous steps
-
+        - notify clients
         """
         failure_conditions = [
             (not self.charm.unit.is_leader(), "Action must be ran on the application leader"),
@@ -168,6 +183,7 @@ class BackupEvents(Object):
                 not self.backup_manager.is_snapshot_in_bucket(id_to_restore),
                 "Backup id not found in storage object",
             ),
+            # TODO: check for ongoing restore
         ]
 
         for check, msg in failure_conditions:
@@ -177,13 +193,221 @@ class BackupEvents(Object):
                 event.fail(msg)
                 return
 
+        self.restore_state.cluster.update(
+            {
+                "id-to-restore": id_to_restore,
+                "restore-instruction": RestoreStep.NOT_STARTED.value,
+            }
+        )
+
+    def _restore_event_dispatch(self, event: RelationEvent):
+        cluster_state = self.restore_state.cluster
+        unit_state = self.restore_state.unit_server
+
+        if not cluster_state.id_to_restore:
+            self.restore_state.unit_server.update(
+                {"restore-progress": RestoreStep.NOT_STARTED.value}
+            )
+            self.charm._set_status(self.charm.state.ready)
+            return
+
+        if self.charm.unit.is_leader():
+            self._maybe_progress_step()
+
+        match cluster_state.restore_instruction, unit_state.restore_progress:
+            case RestoreStep.STOP_WORKFLOW, RestoreStep.NOT_STARTED:
+                self._stop_workflow()
+            case RestoreStep.RESTORE, RestoreStep.STOP_WORKFLOW:
+                self._download_and_restore()
+            case RestoreStep.RESTART, RestoreStep.RESTORE:
+                self._restart_workflow()
+            case RestoreStep.CLEAN, RestoreStep.RESTART:
+                self._cleaning()
+            case _:
+                pass
+
+    def _maybe_progress_step(self):
+        """Check that all units are done with the current restore flow instruction and move to the next if applicable."""
+        current_instruction = self.restore_state.cluster.restore_instruction
+        next_instruction = current_instruction.next_step()
+
+        if all(
+            (unit.restore_progress is current_instruction for unit in self.restore_state.servers)
+        ):
+            payload = {"restore-instruction": next_instruction.value}
+            if current_instruction is RestoreStep.CLEAN:
+                payload = payload | {"id-to-restore": "", "to_restore": ""}
+                # TODO: notify clients
+
+            self.restore_state.cluster.update(payload)
+
+    def _stop_workflow(self):
         self.charm._set_status(Status.ONGOING_RESTORE)
+        logger.info("Restoring - stopping workflow")
+        self.charm.workload.stop()
+        self.restore_state.unit_server.update(
+            {"restore-progress": RestoreStep.STOP_WORKFLOW.value}
+        )
 
-        # do stuff
-        import time
+    def _download_and_restore(self):
+        logger.info("Restoring - downloading snapshot")
+        # TODO
+        self.charm.workload.write(
+            self.restore_state.cluster.id_to_restore,
+            "/var/snap/charmed-zookeeper/current/etc/zookeeper/restored",
+        )
+        self.restore_state.unit_server.update({"restore-progress": RestoreStep.RESTORE.value})
 
-        time.sleep(10)
+    def _restart_workflow(self):
+        logger.info("Restoring - restarting workflow")
+        self.charm.workload.restart()
+        self.restore_state.unit_server.update({"restore-progress": RestoreStep.RESTART.value})
 
-        # check everything ok
+    def _cleaning(self):
+        logger.info("Restoring - cleaning files")
+        # TODO
+        self.restore_state.unit_server.update({"restore-progress": RestoreStep.CLEAN.value})
 
-        self.charm._set_status(self.charm.state.stable)
+
+class RestoreStep(str, Enum):
+    """Represent restore flow step."""
+
+    NOT_STARTED = ""
+    STOP_WORKFLOW = "stop"
+    RESTORE = "restore"
+    RESTART = "restart"
+    CLEAN = "clean"
+
+    def next_step(self):
+        """Get the next logical restore flow step."""
+        match self:
+            case RestoreStep.NOT_STARTED:
+                return RestoreStep.STOP_WORKFLOW
+            case RestoreStep.STOP_WORKFLOW:
+                return RestoreStep.RESTORE
+            case RestoreStep.RESTORE:
+                return RestoreStep.RESTART
+            case RestoreStep.RESTART:
+                return RestoreStep.CLEAN
+            case RestoreStep.CLEAN:
+                return RestoreStep.NOT_STARTED
+
+
+class ZKServerRestore(RelationState):
+    """Restore-focused state collection metadata for a charm unit."""
+
+    def __init__(
+        self,
+        relation: Relation | None,
+        data_interface: DataPeerUnitData,
+        component: Unit,
+        substrate: SUBSTRATES,
+    ):
+        super().__init__(relation, data_interface, component, substrate)
+        self.unit = component
+
+    @property
+    def restore_progress(self) -> RestoreStep:
+        """Latest restore flow step the unit went through."""
+        return RestoreStep(self.relation_data.get("restore-progress", ""))
+
+
+class ZKClusterRestore(RelationState):
+    """Restore-focused state collection metadata for the charm application."""
+
+    def __init__(
+        self,
+        relation: Relation | None,
+        data_interface: DataPeerData,
+        component: Application,
+        substrate: SUBSTRATES,
+    ):
+        super().__init__(relation, data_interface, component, substrate)
+        self.data_interface = data_interface
+        self.app = component
+
+    @property
+    def id_to_restore(self) -> str:
+        """Backup id to restore."""
+        return self.relation_data.get("id-to-restore", "")
+
+    @property
+    def restore_instruction(self) -> RestoreStep:
+        """Current restore flow step to go through."""
+        return RestoreStep(self.relation_data.get("restore-instruction", ""))
+
+
+class RestoreState(Object):
+    """Collection of global cluster state for Framework/Object."""
+
+    def __init__(self, charm: Object, substrate: SUBSTRATES):
+        super().__init__(parent=charm, key="restore_state")
+        self.substrate: SUBSTRATES = substrate
+
+        self.peer_app_interface = DataPeerData(self.model, relation_name=RESTORE)
+        self.peer_unit_interface = DataPeerUnitData(self.model, relation_name=RESTORE)
+        self._servers_data = {}
+
+    @property
+    def peer_relation(self) -> Relation | None:
+        """The cluster peer relation."""
+        return self.model.get_relation(RESTORE)
+
+    # --- CORE COMPONENTS---
+
+    @property
+    def unit_server(self) -> ZKServerRestore:
+        """The server state of the current running Unit."""
+        return ZKServerRestore(
+            relation=self.peer_relation,
+            data_interface=self.peer_unit_interface,
+            component=self.model.unit,
+            substrate=self.substrate,
+        )
+
+    @property
+    def peer_units_data_interfaces(self) -> dict[Unit, DataPeerOtherUnitData]:
+        """The cluster peer relation."""
+        if not self.peer_relation or not self.peer_relation.units:
+            return {}
+
+        for unit in self.peer_relation.units:
+            if unit not in self._servers_data:
+                self._servers_data[unit] = DataPeerOtherUnitData(
+                    model=self.model, unit=unit, relation_name=RESTORE
+                )
+        return self._servers_data
+
+    @property
+    def cluster(self) -> ZKClusterRestore:
+        """The cluster state of the current running App."""
+        return ZKClusterRestore(
+            relation=self.peer_relation,
+            data_interface=self.peer_app_interface,
+            component=self.model.app,
+            substrate=self.substrate,
+        )
+
+    @property
+    def servers(self) -> set[ZKServerRestore]:
+        """Grabs all servers in the current peer relation, including the running unit server.
+
+        Returns:
+            Set of ZKServers in the current peer relation, including the running unit server.
+        """
+        if not self.peer_relation:
+            return set()
+
+        servers = set()
+        for unit, data_interface in self.peer_units_data_interfaces.items():
+            servers.add(
+                ZKServerRestore(
+                    relation=self.peer_relation,
+                    data_interface=data_interface,
+                    component=unit,
+                    substrate=self.substrate,
+                )
+            )
+        servers.add(self.unit_server)
+
+        return servers

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -199,11 +199,9 @@ class BackupEvents(Object):
 
     def _restore_event_dispatch(self, event: RelationEvent):
         """Dispatch restore event to the proper method."""
-        cluster_state = self.charm.state.cluster
-        unit_state = self.charm.state.unit_server
 
-        if not cluster_state.id_to_restore:
-            if unit_state.restore_progress is not RestoreStep.NOT_STARTED:
+        if not self.charm.state.cluster.id_to_restore:
+            if self.charm.state.unit_server.restore_progress is not RestoreStep.NOT_STARTED:
                 self.charm.state.unit_server.update(
                     {"restore-progress": RestoreStep.NOT_STARTED.value}
                 )
@@ -213,7 +211,7 @@ class BackupEvents(Object):
         if self.charm.unit.is_leader():
             self._maybe_progress_step()
 
-        match cluster_state.restore_instruction, unit_state.restore_progress:
+        match self.charm.state.cluster.restore_instruction, self.charm.state.unit_server.restore_progress:
             case RestoreStep.STOP_WORKFLOW, RestoreStep.NOT_STARTED:
                 self._stop_workflow()
             case RestoreStep.RESTORE, RestoreStep.STOP_WORKFLOW:

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -3,6 +3,8 @@
 # See LICENSE file for licensing details.
 
 """Event handlers for creating and restoring backups."""
+from __future__ import annotations
+
 import json
 import logging
 from enum import Enum
@@ -43,7 +45,7 @@ class BackupEvents(Object):
 
     def __init__(self, charm):
         super().__init__(charm, "backup")
-        self.charm: "ZooKeeperCharm" = charm
+        self.charm: ZooKeeperCharm = charm
         self.restore_state = RestoreState(self.charm, substrate=SUBSTRATE)
         self.s3_requirer = S3Requirer(self.charm, S3_REL_NAME)
         self.backup_manager = BackupManager(self.charm.state)
@@ -250,11 +252,10 @@ class BackupEvents(Object):
         )
 
     def _download_and_restore(self):
-        logger.info("Restoring - downloading snapshot")
+        logger.info("Restoring - restore snapshot")
         # TODO
-        self.charm.workload.write(
-            self.restore_state.cluster.id_to_restore,
-            "/var/snap/charmed-zookeeper/current/etc/zookeeper/restored",
+        self.backup_manager.restore_snapshot(
+            self.restore_state.cluster.id_to_restore, self.charm.workload
         )
         self.restore_state.unit_server.update({"restore-progress": RestoreStep.RESTORE.value})
 

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -49,7 +49,7 @@ class ProviderEvents(Object):
         Future `client_relation_changed` events called on non-leader units checks passwords before
             restarting.
         """
-        if not self.charm.unit.is_leader() or self.charm.state.cluster.id_to_restore:
+        if not self.charm.unit.is_leader() or self.charm.state.cluster.is_restore_in_progress:
             return
 
         if not self.charm.state.stable:

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -49,7 +49,7 @@ class ProviderEvents(Object):
         Future `client_relation_changed` events called on non-leader units checks passwords before
             restarting.
         """
-        if not self.charm.unit.is_leader():
+        if not self.charm.unit.is_leader() or self.charm.state.cluster.id_to_restore:
             return
 
         if not self.charm.state.stable:

--- a/src/literals.py
+++ b/src/literals.py
@@ -17,6 +17,7 @@ CHARM_KEY = "zookeeper"
 
 PEER = "cluster"
 REL_NAME = "zookeeper"
+RESTORE = "restore"
 CONTAINER = "zookeeper"
 CHARM_USERS = ["super", "sync"]
 CERTS_REL_NAME = "certificates"

--- a/src/literals.py
+++ b/src/literals.py
@@ -106,6 +106,7 @@ class Status(Enum):
         BlockedStatus("invalid s3 configuration - missing mandatory parameters"), "ERROR"
     )
     BUCKET_NOT_CREATED = StatusLevel(BlockedStatus("cannot create s3 bucket"), "ERROR")
+    ONGOING_RESTORE = StatusLevel(MaintenanceStatus("restoring backup"), "INFO")
 
 
 SECRETS_APP = ["sync-password", "super-password", "s3-credentials"]

--- a/src/literals.py
+++ b/src/literals.py
@@ -17,7 +17,6 @@ CHARM_KEY = "zookeeper"
 
 PEER = "cluster"
 REL_NAME = "zookeeper"
-RESTORE = "restore"
 CONTAINER = "zookeeper"
 CHARM_USERS = ["super", "sync"]
 CERTS_REL_NAME = "certificates"

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 """Helpers for managing backups."""
-from __future__ import annotations
 
 import logging
 import os
@@ -12,7 +11,6 @@ from io import BytesIO, StringIO
 from itertools import islice
 from operator import attrgetter
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import boto3
 import httpx
@@ -23,12 +21,11 @@ from mypy_boto3_s3.service_resource import Bucket
 from rich.console import Console
 from rich.table import Table
 
+from core.cluster import ClusterState
 from core.stubs import BackupMetadata, S3ConnectionInfo
 from literals import ADMIN_SERVER_PORT, PATHS, S3_BACKUPS_LIMIT, S3_BACKUPS_PATH, USER
+from workload import ZKWorkload
 
-if TYPE_CHECKING:
-    from core.cluster import ClusterState
-    from workload import ZKWorkload
 
 logger = logging.getLogger(__name__)
 

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -203,7 +203,7 @@ class BackupManager:
     def restore_snapshot(self, backup_id: str, workload: ZKWorkload) -> None:
         """Download and restore a snapshot.
 
-        Restoring requires removing the previous files on disk. For good measure, we move them to a backup folder,
+        Restoring requires removing the previous files on disk. In this step, we move them to a backup folder,
         so that we can manually restore them if something goes wrong.
         """
         data_dir = Path(PATHS["DATA"]) / "data" / "version-2"
@@ -223,6 +223,14 @@ class BackupManager:
         )
 
         workload.exec(["bash", "-c", f"chown {USER}:{USER} {restored_snapshot}"])
+
+    def cleanup_leftover_files(self, workload: ZKWorkload) -> None:
+        """Cleanup the files previously stored in the data and data-log directories."""
+        data_dir = Path(PATHS["DATA"]) / "data" / "version-2.bak"
+        data_log_dir = Path(PATHS["DATA"]) / "data-log" / "version-2.bak"
+
+        workload.exec(["bash", "-c", f"rm -rf {data_dir}"])
+        workload.exec(["bash", "-c", f"rm -rf {data_log_dir}"])
 
 
 class _StreamingToFileSyncAdapter:

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -177,6 +177,23 @@ class BackupManager:
 
         return out_f.getvalue()
 
+    def is_snapshot_in_bucket(self, backup_id: str) -> bool:
+        """Check whether the requested snapshot to restore is in the object storage."""
+        try:
+            bucket = self.bucket
+        except KeyError:
+            return False
+
+        try:
+            content = bucket.meta.client.head_object(
+                Bucket=bucket.name, Key=os.path.join(self.backups_path, backup_id, "snapshot")
+            )
+        except ClientError as ex:
+            if "(404)" in ex.args[0]:
+                return False
+            raise
+        return content.get("ResponseMetadata", None) is not None
+
 
 class _StreamingToFileSyncAdapter:
     """Wrapper to make httpx.stream behave like a file-like object.

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -14,7 +14,7 @@ from operator import attrgetter
 import boto3
 import httpx
 import yaml
-from botocore import loaders, regions
+from botocore import loaders, regions, config
 from botocore.exceptions import ClientError
 from mypy_boto3_s3.service_resource import Bucket
 from rich.console import Console
@@ -45,6 +45,7 @@ class BackupManager:
             aws_secret_access_key=s3_parameters["secret-key"],
             region_name=s3_parameters["region"] if s3_parameters["region"] else None,
             endpoint_url=self._construct_endpoint(s3_parameters),
+            config=config.Config(retries={"mode": "standard", "max_attempts": 3}),
         )
         return s3.Bucket(s3_parameters["bucket"])
 

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 """Helpers for managing backups."""
+from __future__ import annotations
 
 import logging
 import os
@@ -10,6 +11,8 @@ from datetime import datetime
 from io import BytesIO, StringIO
 from itertools import islice
 from operator import attrgetter
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import boto3
 import httpx
@@ -20,9 +23,12 @@ from mypy_boto3_s3.service_resource import Bucket
 from rich.console import Console
 from rich.table import Table
 
-from core.cluster import ClusterState
 from core.stubs import BackupMetadata, S3ConnectionInfo
-from literals import ADMIN_SERVER_PORT, S3_BACKUPS_LIMIT, S3_BACKUPS_PATH
+from literals import ADMIN_SERVER_PORT, PATHS, S3_BACKUPS_LIMIT, S3_BACKUPS_PATH, USER
+
+if TYPE_CHECKING:
+    from core.cluster import ClusterState
+    from workload import ZKWorkload
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +199,30 @@ class BackupManager:
                 return False
             raise
         return content.get("ResponseMetadata", None) is not None
+
+    def restore_snapshot(self, backup_id: str, workload: ZKWorkload) -> None:
+        """Download and restore a snapshot.
+
+        Restoring requires removing the previous files on disk. For good measure, we move them to a backup folder,
+        so that we can manually restore them if something goes wrong.
+        """
+        data_dir = Path(PATHS["DATA"]) / "data" / "version-2"
+        data_log_dir = Path(PATHS["DATA"]) / "data-log" / "version-2"
+
+        workload.exec(["bash", "-c", f"cp -rp {data_dir} {data_dir.parent / 'version-2.bak'}"])
+        workload.exec(
+            ["bash", "-c", f"cp -rp {data_log_dir} {data_log_dir.parent / 'version-2.bak'}"]
+        )
+
+        workload.exec(["bash", "-c", f"rm -rf {data_dir / '*'}"])
+        workload.exec(["bash", "-c", f"rm -rf {data_log_dir / '*'}"])
+
+        restored_snapshot = data_dir / "snapshot.0"
+        self.bucket.Object(os.path.join(self.backups_path, backup_id, "snapshot")).download_file(
+            f"{restored_snapshot}"
+        )
+
+        workload.exec(["bash", "-c", f"chown {USER}:{USER} {restored_snapshot}"])
 
 
 class _StreamingToFileSyncAdapter:

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -195,7 +195,7 @@ class BackupManager:
             if "(404)" in ex.args[0]:
                 return False
             raise
-        return content.get("ResponseMetadata", None) is not None
+        return bool(content.get("ResponseMetadata", None))
 
     def restore_snapshot(self, backup_id: str, workload: ZKWorkload) -> None:
         """Download and restore a snapshot.

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -14,7 +14,7 @@ from operator import attrgetter
 import boto3
 import httpx
 import yaml
-from botocore import loaders, regions, config
+from botocore import config, loaders, regions
 from botocore.exceptions import ClientError
 from mypy_boto3_s3.service_resource import Bucket
 from rich.console import Console

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -26,7 +26,6 @@ from core.stubs import BackupMetadata, S3ConnectionInfo
 from literals import ADMIN_SERVER_PORT, PATHS, S3_BACKUPS_LIMIT, S3_BACKUPS_PATH, USER
 from workload import ZKWorkload
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -183,13 +182,8 @@ class BackupManager:
     def is_snapshot_in_bucket(self, backup_id: str) -> bool:
         """Check whether the requested snapshot to restore is in the object storage."""
         try:
-            bucket = self.bucket
-        except KeyError:
-            return False
-
-        try:
-            content = bucket.meta.client.head_object(
-                Bucket=bucket.name, Key=os.path.join(self.backups_path, backup_id, "snapshot")
+            content = self.bucket.meta.client.head_object(
+                Bucket=self.bucket.name, Key=os.path.join(self.backups_path, backup_id, "snapshot")
             )
         except ClientError as ex:
             if "(404)" in ex.args[0]:

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -233,7 +233,16 @@ class QuorumManager:
                 self.client.set_acls_znode_leader(path=node, acls=[generated_acl])
 
         # Looks for applications no longer in the relation but still in config
+        restricted_acl = make_acl(
+            scheme="sasl",
+            credential="super",
+            read=True,
+            write=True,
+            create=True,
+            delete=True,
+            admin=True,
+        )
         for chroot in sorted(leader_chroots - requested_chroots, reverse=True):
             if not self._is_child_of(chroot, requested_chroots):
                 logger.info(f"RESET ACLS CHROOT - {chroot}")
-                self.client.set_acls_znode_leader(path=chroot, acls=[])
+                self.client.set_acls_znode_leader(path=chroot, acls=[restricted_acl])

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -235,5 +235,5 @@ class QuorumManager:
         # Looks for applications no longer in the relation but still in config
         for chroot in sorted(leader_chroots - requested_chroots, reverse=True):
             if not self._is_child_of(chroot, requested_chroots):
-                logger.info(f"DROP CHROOT - {chroot}")
-                self.client.delete_znode_leader(path=chroot)
+                logger.info(f"RESET ACLS CHROOT - {chroot}")
+                self.client.set_acls_znode_leader(path=chroot, acls=[])

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -236,11 +236,7 @@ class QuorumManager:
         restricted_acl = make_acl(
             scheme="sasl",
             credential="super",
-            read=True,
-            write=True,
-            create=True,
-            delete=True,
-            admin=True,
+            all=True,
         )
         for chroot in sorted(leader_chroots - requested_chroots, reverse=True):
             if not self._is_child_of(chroot, requested_chroots):

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -228,6 +228,10 @@ class QuorumManager:
             logger.debug(f"UPDATE CHROOT - {client.database}")
             self.client.set_acls_znode_leader(path=client.database, acls=[generated_acl])
 
+            subnodes = self.client.leader_znodes(path=client.database)
+            for node in subnodes:
+                self.client.set_acls_znode_leader(path=node, acls=[generated_acl])
+
         # Looks for applications no longer in the relation but still in config
         for chroot in sorted(leader_chroots - requested_chroots, reverse=True):
             if not self._is_child_of(chroot, requested_chroots):

--- a/tests/integration/test_backup.py
+++ b/tests/integration/test_backup.py
@@ -137,9 +137,7 @@ async def test_restore_backup_new_app(ops_test: OpsTest, s3_bucket: Bucket, zk_c
     )
     await ops_test.model.add_relation(APP_TO_RESTORE, S3_INTEGRATOR)
     await ops_test.model.wait_for_idle(
-        apps=[APP_TO_RESTORE, S3_INTEGRATOR],
-        status="active",
-        timeout=1000,
+        apps=[APP_TO_RESTORE, S3_INTEGRATOR], status="active", timeout=1000, raise_on_error=False
     )
     for unit in ops_test.model.applications[APP_TO_RESTORE].units:
         if await unit.is_leader_from_status():

--- a/tests/unit/scenario/test_backup.py
+++ b/tests/unit/scenario/test_backup.py
@@ -231,3 +231,76 @@ def test_action_list_backups_no_creds(ctx: Context, base_state: State):
     assert (
         exc_info.value.message == "Cluster needs an access to an object storage to make a backup"
     )
+
+
+def test_action_restore_not_leader(ctx: Context, base_state: State):
+    # Given
+    state_in = dataclasses.replace(base_state, leader=False)
+
+    # When
+    # Then
+    with pytest.raises(ActionFailed) as exc_info:
+        _ = ctx.run(ctx.on.action("restore"), state_in)
+
+    assert exc_info.value.message == "Action must be ran on the application leader"
+
+
+def test_action_restore_no_creds(ctx: Context, base_state: State):
+    # Given
+    state_in = base_state
+
+    # When
+    # Then
+    with pytest.raises(ActionFailed) as exc_info:
+        _ = ctx.run(ctx.on.action("restore"), state_in)
+
+    assert (
+        exc_info.value.message == "Cluster needs an access to an object storage to make a backup"
+    )
+
+
+def test_action_restore_no_id_param(ctx: Context, base_state: State):
+    # Given
+    s3_params = {
+        "access-key": "speakfriend",
+        "secret-key": "mellon",
+        "bucket": "moria",
+        "region": "",
+    }
+    state_in = base_state
+
+    # When
+    # Then
+    with (
+        pytest.raises(ActionFailed) as exc_info,
+        patch("core.models.ZKCluster.s3_credentials", new_callable=PropertyMock, value=s3_params),
+        patch("managers.backup.BackupManager.is_snapshot_in_bucket", side_effect=[False]),
+    ):
+        _ = ctx.run(ctx.on.action("restore"), state_in)
+
+    assert exc_info.value.message == "No backup id to restore provided"
+
+
+def test_action_restore_snapshot_not_found(ctx: Context, base_state: State):
+    # Given
+    s3_params = {
+        "access-key": "speakfriend",
+        "secret-key": "mellon",
+        "bucket": "moria",
+        "region": "",
+    }
+    state_in = base_state
+
+    # When
+    # Then
+    with (
+        pytest.raises(ActionFailed) as exc_info,
+        patch("core.models.ZKCluster.s3_credentials", new_callable=PropertyMock, value=s3_params),
+        patch("managers.backup.BackupManager.is_snapshot_in_bucket", side_effect=[False]),
+    ):
+        _ = ctx.run(ctx.on.action("restore", params={"backup-id": "notfound"}), state_in)
+
+    assert exc_info.value.message == "Backup id not found in storage object"
+
+
+# TODO: Add test for ongoing restore

--- a/tests/unit/scenario/test_backup.py
+++ b/tests/unit/scenario/test_backup.py
@@ -17,6 +17,7 @@ from charm import ZooKeeperCharm
 from literals import (
     CONTAINER,
     PEER,
+    RESTORE,
     S3_REL_NAME,
     SUBSTRATE,
     Status,
@@ -303,4 +304,26 @@ def test_action_restore_snapshot_not_found(ctx: Context, base_state: State):
     assert exc_info.value.message == "Backup id not found in storage object"
 
 
-# TODO: Add test for ongoing restore
+def test_action_restore_ongoing_restore(ctx: Context, base_state: State):
+    # Given
+    s3_params = {
+        "access-key": "speakfriend",
+        "secret-key": "mellon",
+        "bucket": "moria",
+        "region": "",
+    }
+    restore_peer = PeerRelation(
+        RESTORE, RESTORE, local_app_data={"id-to-restore": "ongoing-backup-id"}
+    )
+    state_in = dataclasses.replace(base_state, relations=[restore_peer])
+
+    # When
+    # Then
+    with (
+        pytest.raises(ActionFailed) as exc_info,
+        patch("core.models.ZKCluster.s3_credentials", new_callable=PropertyMock, value=s3_params),
+        patch("managers.backup.BackupManager.is_snapshot_in_bucket", side_effect=[True]),
+    ):
+        _ = ctx.run(ctx.on.action("restore", params={"backup-id": "new-backup-id"}), state_in)
+
+    assert exc_info.value.message == "A snapshot restore is currently ongoing"

--- a/tests/unit/scenario/test_backup.py
+++ b/tests/unit/scenario/test_backup.py
@@ -17,7 +17,6 @@ from charm import ZooKeeperCharm
 from literals import (
     CONTAINER,
     PEER,
-    RESTORE,
     S3_REL_NAME,
     SUBSTRATE,
     Status,
@@ -312,9 +311,7 @@ def test_action_restore_ongoing_restore(ctx: Context, base_state: State):
         "bucket": "moria",
         "region": "",
     }
-    restore_peer = PeerRelation(
-        RESTORE, RESTORE, local_app_data={"id-to-restore": "ongoing-backup-id"}
-    )
+    restore_peer = PeerRelation(PEER, PEER, local_app_data={"id-to-restore": "ongoing-backup-id"})
     state_in = dataclasses.replace(base_state, relations=[restore_peer])
 
     # When

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -501,6 +501,7 @@ def test_init_server_sets_blocked_if_not_alive(harness):
         patch("managers.config.ConfigManager.set_zookeeper_dynamic_properties"),
         patch("managers.config.ConfigManager.set_zookeeper_properties"),
         patch("managers.config.ConfigManager.set_jaas_config"),
+        patch("managers.config.ConfigManager.set_client_jaas_config"),
         patch("workload.ZKWorkload.start"),
         patch("workload.ZKWorkload.alive", new_callable=PropertyMock, return_value=False),
     ):
@@ -543,6 +544,9 @@ def test_init_server_calls_necessary_methods(harness):
         ) as zookeeper_dynamic_properties,
         patch("managers.config.ConfigManager.set_zookeeper_properties") as zookeeper_properties,
         patch("managers.config.ConfigManager.set_jaas_config") as zookeeper_jaas_config,
+        patch(
+            "managers.config.ConfigManager.set_client_jaas_config"
+        ) as zookeeper_client_jaas_config,
         patch("managers.tls.TLSManager.set_private_key") as patched_private_key,
         patch("managers.tls.TLSManager.set_ca") as patched_ca,
         patch("managers.tls.TLSManager.set_certificate") as patched_certificate,
@@ -557,6 +561,7 @@ def test_init_server_calls_necessary_methods(harness):
         zookeeper_dynamic_properties.assert_called_once()
         zookeeper_properties.assert_called_once()
         zookeeper_jaas_config.assert_called_once()
+        zookeeper_client_jaas_config.assert_called_once()
         patched_private_key.assert_called_once()
         patched_ca.assert_called_once()
         patched_certificate.assert_called_once()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -207,6 +207,7 @@ def test_config_changed_updates_properties_jaas_hosts(harness):
         ),
         patch("managers.config.ConfigManager.static_properties", return_value="gandalf=grey"),
         patch("managers.config.ConfigManager.set_jaas_config"),
+        patch("managers.config.ConfigManager.set_client_jaas_config"),
         patch("managers.config.ConfigManager.set_zookeeper_properties") as set_props,
         patch("managers.config.ConfigManager.set_server_jvmflags"),
     ):
@@ -218,10 +219,12 @@ def test_config_changed_updates_properties_jaas_hosts(harness):
         patch("workload.ZKWorkload.read", return_value=["gandalf=grey"]),
         patch("managers.config.ConfigManager.set_zookeeper_properties"),
         patch("managers.config.ConfigManager.set_jaas_config") as set_jaas,
+        patch("managers.config.ConfigManager.set_client_jaas_config") as set_client_jaas,
         patch("managers.config.ConfigManager.set_server_jvmflags"),
     ):
         harness.charm.config_manager.config_changed()
         set_jaas.assert_called_once()
+        set_client_jaas.assert_called_once()
 
 
 def test_update_environment(harness):

--- a/tests/unit/test_quorum.py
+++ b/tests/unit/test_quorum.py
@@ -113,8 +113,8 @@ def test_update_acls_correctly_handles_relation_chroots(harness):
         for _, kwargs in patched_manager["create_znode_leader"].call_args_list:
             assert "/rohan" in kwargs["path"]
 
-        for _, kwargs in patched_manager["set_acls_znode_leader"].call_args_list:
-            assert "/rohan" in kwargs["path"]
+        _, kwargs = patched_manager["set_acls_znode_leader"].call_args_list[0]
+        assert "/rohan" in kwargs["path"]
 
         removed_men = False
         for counter, call in enumerate(patched_manager["delete_znode_leader"].call_args_list):

--- a/tests/unit/test_quorum.py
+++ b/tests/unit/test_quorum.py
@@ -116,17 +116,9 @@ def test_update_acls_correctly_handles_relation_chroots(harness):
         _, kwargs = patched_manager["set_acls_znode_leader"].call_args_list[0]
         assert "/rohan" in kwargs["path"]
 
-        removed_men = False
-        for counter, call in enumerate(patched_manager["delete_znode_leader"].call_args_list):
-            _, kwargs = call
+        paths_updated = {
+            kwargs["path"] for _, kwargs in patched_manager["set_acls_znode_leader"].call_args_list
+        }
 
-            if "/fellowship/men" in kwargs["path"]:
-                assert not removed_men, "Parent zNode removed before all it's children"
-
-            if kwargs["path"] == "/fellowship/men":
-                removed_men = True
-
-        # ensure last node to go is the parent
-        assert (
-            patched_manager["delete_znode_leader"].call_args_list[-1][1]["path"] == "/fellowship"
-        )
+        # all paths saw their acls updated
+        assert not dummy_leader_znodes - paths_updated

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -174,6 +174,7 @@ def test_run_password_rotation_while_upgrading(harness, mocker, upgrade_stack):
         mocker.patch.object(ConfigManager, "set_zookeeper_dynamic_properties"),
         mocker.patch.object(ConfigManager, "set_zookeeper_properties"),
         mocker.patch.object(ConfigManager, "set_jaas_config"),
+        mocker.patch.object(ConfigManager, "set_client_jaas_config"),
         patch("charm.ZooKeeperCharm.update_quorum"),
     ):
         harness.charm.password_action_events._set_password_action(mock_event)


### PR DESCRIPTION
This PR implements the flow for restoring a ZooKeeper snapshot.

## Other changes

- Add retry configuration to S3 resource in case of flaky network.
- Recursively update ACLs if the requested zNode already exists
- Write a `client-jaas.cfg` file to streamline a little bit the process of accessing the ZK cluster within the machine.
- Update ACLs to only let the superuser access the path for zNodes that are not currently requested by a related client application

## Use cases

This flow can be used to bootstrap a new cluster using seeded data. Upon relating with a new client application, let's say, Kafka, here is what is going to happen:
- the ACLs for `/kafka` and its subnodes will be updated to the new relation, if it already existed
- Kafka's relation flow will recreate its `admin` and `sync` users, but, we will keep others pre-existing users (and other sub zNodes around). 
- The other zNodes which were already present in the restored snapshot will see their ACL reset to only the ZK superuser, instead of being deleted 

With a minimal change in the Kafka charm, we can also restore a snapshot on an already related ZK application. The chain of events will be as follows:
- Clients will be disconnected by removing the `endpoints` field from the databag. On Kafka, this has the effect of triggering the `relation-changed` event and setting the application's status to `ZK_NO_DATA`
- We can then follow the same procedure as above after restoring the snapshot. Re-writing the databag with the required fields will trigger the `relation-changed` event. Kafka relation flow will then rotate the `admin` and `sync` user passwords

Here is the patch for Kafka:

```diff
diff --git a/src/events/zookeeper.py b/src/events/zookeeper.py
index 4b4f5a5..5a1adc0 100644
--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -71,7 +71,7 @@ class ZooKeeperHandler(Object):
             event.defer()
             return
 
-        if not self.charm.state.cluster.internal_user_credentials and self.model.unit.is_leader():
+        if self.model.unit.is_leader():
             # loading the minimum config needed to authenticate to zookeeper
             self.dependent.config_manager.set_zk_jaas_config()
             self.dependent.config_manager.set_server_properties()
@@ -87,6 +87,12 @@ class ZooKeeperHandler(Object):
             for username, password in internal_user_credentials:
                 self.charm.state.cluster.update({f"{username}-password": password})
 
+        # Kafka keeps a meta.properties in every log.dir with a unique ClusterID
+        # this ID is provided by ZK, and removing it on relation-changed allows
+        # re-joining to another ZK cluster while restoring.
+        for storage in self.charm.model.storages["data"]:
+            self.charm.workload.exec(["rm", f"{storage.location}/meta.properties"])
+
         # attempt re-start of Kafka for all units on zookeeper-changed
         # avoids relying on deferred events elsewhere that may not exist after cluster init
         if not self.dependent.healthy:

```


## About the restore flow

- Since we need to operate the workload on all units, we use a chain of events instead of staying within the context of the action execution.
- We want to synchronize the units while they follow these steps:
     - stop the workload
     - move the existing data away, and download the snapshot there
     - restart the workload
     - cleanup leftover files
     
     Therefore, we do not use the rolling ops lib, and use a different peer relation to manage this flow, making sure all units are done with a step before moving on to the next.
~~- Instead of using the peer `cluster` relation, we now have a new `restore` one. There are two main reasons why:~~
    ~~- it makes following the chain of events way easier because the dozens of events fired during the flow do not trigger the "something changed" `cluster-relation-changed`~~
    ~~- this separation of concerns guarantees that if anything goes wrong, we can ssh into the machine to solve this issue, and then continue with the flow using `juju resolve`. This is also why we do not have defers or try except for the `exec` calls~~
NEW: we use the peer `cluster` relation instead of the dedicated `restore` from earlier commits.


## TODO

- [x] Add action message after initiating the restore flow
- [x] Notify clients upon completion. How can we restart the relation-changed chain of events?
- [x] Block / defer other operations during restore
- [x] Add integration tests
- [x] Move around stuff? Should the new peer relation interface go some place else, like core/cluster or core/models?
- [x] Reset ACLs instead of removing the zNodes upon relation departure, following the team discussion on MM
- [x] Cleanup old files


## Demo


https://github.com/user-attachments/assets/07a5d880-1b18-4668-9eea-fbc18287fb04


