### PR TITLE
fix: don't erase previous record from /etc/hosts

### DIFF
--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -280,15 +280,14 @@ class ConfigManager:
         Returns:
             Multiline string of `/etc/hosts` entries
         """
-        current_etc_hosts = self.workload.read(path="/etc/hosts")
-        hosts_entries = set(current_etc_hosts)
+        hosts_entries = []
         for server in self.state.servers:
             if not all([server.ip, server.hostname, server.fqdn]):
-                continue
+                return []
 
-            hosts_entries.add(f"{server.ip} {server.fqdn} {server.hostname}")
+            hosts_entries.append(f"{server.ip} {server.fqdn} {server.hostname}")
 
-        return list(hosts_entries)
+        return hosts_entries
 
     def _update_environment(self, env: dict[str, str]) -> None:
         """Updates the /etc/environment for the workload.
@@ -309,9 +308,31 @@ class ConfigManager:
 
         self.workload.write(content=content, path="/etc/environment")
 
+    def _parse_etc_hosts(self) -> dict[str, str]:
+        """Returns a mapping of `FQDN hostname` to IP addresses based on /etc/hosts entries."""
+        records = {
+            line for line in self.workload.read(path="/etc/hosts") if not line.startswith("#")
+        }
+        mapping = {}
+        for record in records:
+            parts = record.strip().split()
+            if parts and len(parts) > 1:
+                mapping[" ".join(parts[1:])] = parts[0]
+        return mapping
+
+    def _update_etc_hosts(self, entries: list[str]) -> list[str]:
+        """Updates previous /etc/hosts entries based on new list of entries in the format `IP FQDN HOSTNAME`."""
+        mapping = self._parse_etc_hosts()
+        for entry in entries:
+            parts = entry.strip().split()
+            if parts and len(parts) > 1:
+                mapping[" ".join(parts[1:])] = parts[0]
+        return [f"{v} {k}" for k, v in mapping.items()]
+
     def set_etc_hosts(self) -> None:
         """Writes to /etc/hosts with peer-related units."""
-        self.workload.write(content="\n".join(self.etc_hosts_entries), path="/etc/hosts")
+        updated_etc_hosts = self._update_etc_hosts(self.etc_hosts_entries)
+        self.workload.write(content="\n".join(updated_etc_hosts), path="/etc/hosts")
 
     def set_jaas_config(self) -> None:
         """Sets the ZooKeeper JAAS config."""

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -332,7 +332,7 @@ class ConfigManager:
     def set_etc_hosts(self) -> None:
         """Writes to /etc/hosts with peer-related units."""
         updated_etc_hosts = self._update_etc_hosts(self.etc_hosts_entries)
-        self.workload.write(content="\n".join(updated_etc_hosts), path="/etc/hosts")
+        self.workload.write(content=("\n".join(updated_etc_hosts) + "\n"), path="/etc/hosts")
 
     def set_jaas_config(self) -> None:
         """Sets the ZooKeeper JAAS config."""

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -280,14 +280,15 @@ class ConfigManager:
         Returns:
             Multiline string of `/etc/hosts` entries
         """
-        hosts_entries = []
+        current_etc_hosts = self.workload.read(path="/etc/hosts")
+        hosts_entries = set(current_etc_hosts)
         for server in self.state.servers:
             if not all([server.ip, server.hostname, server.fqdn]):
-                return []
+                continue
 
-            hosts_entries.append(f"{server.ip} {server.fqdn} {server.hostname}")
+            hosts_entries.add(f"{server.ip} {server.fqdn} {server.hostname}")
 
-        return hosts_entries
+        return list(hosts_entries)
 
     def _update_environment(self, env: dict[str, str]) -> None:
         """Updates the /etc/environment for the workload.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -39,6 +39,7 @@ def ctx() -> Context:
     return ctx
 
 
+@pytest.mark.skip
 def test_etc_hosts_entries_empty_if_not_all_units_related(ctx: Context, base_state: State) -> None:
     # Given
     cluster_peer = PeerRelation(
@@ -58,6 +59,7 @@ def test_etc_hosts_entries_empty_if_not_all_units_related(ctx: Context, base_sta
         assert not charm.config_manager.etc_hosts_entries
 
 
+@pytest.mark.skip
 def test_etc_hosts_entries_empty_if_unit_not_yet_set(ctx: Context, base_state: State) -> None:
     # Given
     cluster_peer = PeerRelation(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -39,7 +39,6 @@ def ctx() -> Context:
     return ctx
 
 
-@pytest.mark.skip
 def test_etc_hosts_entries_empty_if_not_all_units_related(ctx: Context, base_state: State) -> None:
     # Given
     cluster_peer = PeerRelation(
@@ -59,7 +58,6 @@ def test_etc_hosts_entries_empty_if_not_all_units_related(ctx: Context, base_sta
         assert not charm.config_manager.etc_hosts_entries
 
 
-@pytest.mark.skip
 def test_etc_hosts_entries_empty_if_unit_not_yet_set(ctx: Context, base_state: State) -> None:
     # Given
     cluster_peer = PeerRelation(


### PR DESCRIPTION
Changes:
- Preserve other /etc/hosts records on update