### PR TITLE
tests: get the relation from the output state

### DIFF
--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -212,7 +212,7 @@ def test_client_relation_broken_removes_passwords(ctx: Context, base_state: Stat
         patch(
             "charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock", autospec=True
         ),
-        ctx(ctx.on.relation_broken(client_relation), state_out) as manager,
+        ctx(ctx.on.relation_broken(state_out.get_relation(client_relation.id)), state_out) as manager,
     ):
         charm = cast(ZooKeeperCharm, manager.charm)
         state_out = manager.run()

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -212,7 +212,9 @@ def test_client_relation_broken_removes_passwords(ctx: Context, base_state: Stat
         patch(
             "charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock", autospec=True
         ),
-        ctx(ctx.on.relation_broken(state_out.get_relation(client_relation.id)), state_out) as manager,
+        ctx(
+            ctx.on.relation_broken(state_out.get_relation(client_relation.id)), state_out
+        ) as manager,
     ):
         charm = cast(ZooKeeperCharm, manager.charm)
         state_out = manager.run()


### PR DESCRIPTION
In the next version of ops[testing], the consistency checker is more strict, and requires the relation passed into the event to be the same object as the one in the state, not just one with the same ID.

This PR fixes a test that passes with current ops but will fail with the next version, by getting the appropriate relation from the output state.

Note that the test is also more correct now, since the relation in output state may differ (e.g. in the databag contents) from the one in the input state.

To validate, you can run the unit test with current ops, and with ops@main.