### PR TITLE
[Docs] Fix the docs build error for shallow clone

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,9 +11,18 @@ build:
   tools:
     python: "3.11"
   jobs:
-    pre_install:
+    post_checkout:
     - git fetch --unshallow || true
-
+    # Cancel building pull requests when there aren't changed in the docs directory.
+    # If there are no changes (git diff exits with 0) we force the command to return with 183.
+    # This is a special exit code on Read the Docs that will cancel the build immediately.
+    # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+    - |
+      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- 'docs/' '.readthedocs.yaml';
+      then
+        exit 183;
+      fi
+      
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: dirhtml


### PR DESCRIPTION
Trying to fix ReadTheDocs builds fail with warning messages for too shallow clone, probably caused by the unshallow command being used at a worng stage of the process.