### PR TITLE
Docs: Adjust terminology for charmed operators

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,13 +138,11 @@ html_context = {
     'repo_default_branch': 'main',
     # Docs location in the repo; used in links for viewing the source files
     #
-
-
     # TODO: To customise the directory, uncomment and update as needed.
     "repo_folder": "/docs/",
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
-    # "sequential_nav": "both",
+    "sequential_nav": "both",
     # TODO: To enable listing contributors on individual pages, set to True
     "display_contributors": False,
 
@@ -153,6 +151,17 @@ html_context = {
 
     # Required for the Edit the page button
     "top_of_page_buttons": ["edit"],
+}
+
+# TODO: To enable the edit button on pages, uncomment and change the link to a
+# public repository on GitHub or Launchpad. Any of the following link domains
+# are accepted:
+# - https://github.com/example-org/example"
+# - https://launchpad.net/example
+# - https://git.launchpad.net/example
+
+html_theme_options = {
+'source_edit_link': 'https://github.com/canonical/zookeeper-operator',
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897

--- a/docs/content/explanation/ha.md
+++ b/docs/content/explanation/ha.md
@@ -14,7 +14,7 @@ For Apache ZooKeeper implementation details, see the [official documentation](ht
 
 ## Number of servers
 
-For Apache ZooKeeper charmed operator the number of servers in a cluster can be easily adjusted by [adding](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-units/#add-a-unit) or [removing](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-units/#remove-a-unit) Juju [units](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/unit/) from the application.
+For Apache ZooKeeper charm the number of servers in a cluster can be easily adjusted by [adding](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-units/#add-a-unit) or [removing](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-units/#remove-a-unit) Juju [units](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/unit/) from the application.
 
 ```{important}
 Always use an odd number of servers in an Apache ZooKeeper cluster for optimal performance and high availability (HA).
@@ -25,7 +25,7 @@ Adding a unit to create an even number does not improve fault tolerance due to q
 A minimum of three servers/units are required in a cluster for HA. A cluster with just two servers is inherently less stable than a single server, because there are two single points of failure. If one of them fails, there are not enough machines to form a majority quorum.
 
 ```{note}
-We recommend deploying Apache ZooKeeper charmed operator with either three or five units for high availability (HA) in production environments.
+We recommend deploying Apache ZooKeeper charm with either three or five units for high availability (HA) in production environments.
 ```
 
 A three-unit ensemble offers optimal performance and resource efficiency while maintaining high availability (HA), tolerating one failed machine.
@@ -34,7 +34,7 @@ A five-unit ensemble enhances durability, tolerating two failures and enabling d
 
 A seven-unit ensemble tolerates up to three failures. However, the larger quorum increases communication overhead, impacting performance.
 
-The Apache ZooKeeper charmed operator includes every active unit in the quorum. Other operational modes are not supported.
+The Apache ZooKeeper charm includes every active unit in the quorum. Other operational modes are not supported.
 
 ## Availability zones
 

--- a/docs/content/how-to/deploy.md
+++ b/docs/content/how-to/deploy.md
@@ -1,7 +1,7 @@
-# How to deploy Apache ZooKeeper charmed operator
+# How to deploy Apache ZooKeeper charm
 
 ```{note}
-For Kubernetes cloud environment (e.g., AKS, EKS), see the Apache ZooKeeper K8s charmed operator documentation instead.
+For Kubernetes cloud environment (e.g., AKS, EKS), see the Apache ZooKeeper K8s charm documentation instead.
 ```
 <!-- TODO add a link to the K8s charm. -->
 
@@ -42,7 +42,7 @@ juju switch <model-name>
 
 ## Deploy the charm
 
-Deploy the Apache ZooKeeper charmed operator:
+Deploy the Apache ZooKeeper charm:
 
 ```
 juju deploy zookeeper -n <units>
@@ -82,7 +82,7 @@ See also: `juju config` command [reference](https://canonical-juju.readthedocs-h
 
 ## Integrate with other charms
 
-To utilise Apache ZooKeeper charmed operator, use the `juju integrate` command (see [reference](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/list-of-juju-cli-commands/integrate/)) to relate/integrate it with other charms. For example, to deploy Apache Kafka charmed operator and integrate with it:
+To utilise Apache ZooKeeper charm, use the `juju integrate` command (see [reference](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/list-of-juju-cli-commands/integrate/)) to relate/integrate it with other charms. For example, to deploy Apache Kafka charm and integrate with it:
 
 ```
 juju deploy kafka --channel 3/stable -n <kafka-units> --trust

--- a/docs/content/how-to/index.md
+++ b/docs/content/how-to/index.md
@@ -1,9 +1,8 @@
 # How to guides
 
-The following guides cover key processes and common tasks for managing and using Apache ZooKeeper charmed operator on machines:
+The following guides cover key processes and common tasks for managing and using Apache ZooKeeper charm:
 
 * How to deploy
-* How to enable monitoring
 
 ```{toctree}
 :hidden:

--- a/docs/content/tutorial/cleanup.md
+++ b/docs/content/tutorial/cleanup.md
@@ -1,6 +1,6 @@
 # Clean up
 
-This is the last part of the Apache ZooKeeper charmed operator tutorial about clean up of used resources. Make sure to complete instruction from the [Integrate](integrate) page before reading further.
+This is the last part of the Apache ZooKeeper charm tutorial about clean up of used resources. Make sure to complete instruction from the [Integrate](integrate) page before reading further.
 
 ## Destroy the Apache ZooKeeper application
 
@@ -33,4 +33,4 @@ Finally, make sure that deletion is complete with `juju status` and remove the J
 juju destroy-model tutorial
 ```
 
-That concludes the clean up process and the Apache ZooKeeper charmed operator tutorial.
+That concludes the clean up process and the Apache ZooKeeper charm tutorial.

--- a/docs/content/tutorial/deploy.md
+++ b/docs/content/tutorial/deploy.md
@@ -1,10 +1,10 @@
 # Deploy
 
-This is the part of the Apache ZooKeeper charmed operator tutorial about deployment and configuration. Make sure to complete instruction from the [Setup](setup) page before reading further.
+This is the part of the Apache ZooKeeper charm tutorial about deployment and configuration. Make sure to complete instruction from the [Setup](setup) page before reading further.
 
 ## Deploy the charm
 
-Apache ZooKeeper charmed operator can be deployed as any other charm via `juju deploy` command:
+Apache ZooKeeper charm can be deployed as any other charm via `juju deploy` command:
 
 ```
 juju deploy zookeeper -n 5

--- a/docs/content/tutorial/index.md
+++ b/docs/content/tutorial/index.md
@@ -1,14 +1,14 @@
-# Apache ZooKeeper charmed operator tutorial
+# Apache ZooKeeper charm tutorial
 
-The Apache ZooKeeper charmed operator simplifies the deployment, management, and scaling of Apache ZooKeeper clusters on your Juju environment. 
+The Apache ZooKeeper charm simplifies the deployment, management, and scaling of Apache ZooKeeper clusters on your Juju environment. 
 
 In this tutorial, we will:
 
 * Set up your environment using LXD and Juju.
-* Deploy Apache ZooKeeper using charmed operator.
+* Deploy Apache ZooKeeper using charm.
 * Integrate Apache ZooKeeper and Apache Kafka charms.
 
-While this tutorial intends to teach you to use Apache ZooKeeper charmed operator, it will be most beneficial if you already have a familiarity with:
+While this tutorial intends to teach you to use Apache ZooKeeper charm, it will be most beneficial if you already have a familiarity with:
 
 * Basic terminal commands
 * [Apache Zookeeper](https://zookeeper.apache.org/) concepts

--- a/docs/content/tutorial/integrate.md
+++ b/docs/content/tutorial/integrate.md
@@ -1,8 +1,8 @@
 # Integrate
 
-This is the part of the Apache ZooKeeper charmed operator tutorial about using Apache ZooKeeper with other charms. Make sure to complete instruction from the [Deploy](deploy) page before reading further.
+This is the part of the Apache ZooKeeper charm tutorial about using Apache ZooKeeper with other charms. Make sure to complete instruction from the [Deploy](deploy) page before reading further.
 
-The main way to use the Apache ZooKeeper charmed operator is to integrate it with another charm via [Juju relations](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/relation/). For that reason we will deploy Apache Kafka charmed operator and integrate them via the [zookeeper interface](https://charmhub.io/integrations/zookeeper/).
+The main way to use the Apache ZooKeeper charm is to integrate it with another charm via [Juju relations](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/relation/). For that reason we will deploy Apache Kafka charm and integrate them via the [zookeeper interface](https://charmhub.io/integrations/zookeeper/).
 
 ## Deploy Apache Kafka
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Apache ZooKeeper is a free, open-source software project by the Apache Software 
 The charm automates the deployment, scaling, and maintenance of Apache ZooKeeper clusters. It manages leader election, configuration, and synchronisation while handling security features like authentication and access control. The operator enables seamless horizontal scaling, service discovery, and automated recovery, reducing manual intervention. It utilises [Juju](https://juju.is/) for simplified life cycle management across cloud, VM, and bare-metal environments.
 
 ```{note}
-This is a [machine](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/machine/ charm. 
+This is a [machine](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/machine/) charm. 
 For deploying on Kubernetes, see [Apache ZooKeeper K8s charm](https://canonical-zookeeper-k8s.readthedocs-hosted.com/).
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,15 @@
-# Apache ZooKeeper charmed operator
+# Apache ZooKeeper charm
 
-Apache ZooKeeper charmed operator is a [Juju charm](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/charm/) that provides automated operations management for Apache ZooKeeper clusters, facilitating highly reliable distributed coordination.
+Apache ZooKeeper charm is a [Juju charm](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/charm/) that provides automated operations management for Apache ZooKeeper clusters, facilitating highly reliable distributed coordination.
 
 Apache ZooKeeper is a free, open-source software project by the Apache Software Foundation. It is a distributed coordination service widely used for managing configuration information, naming, synchronisation, and group services in distributed systems. Find out more at the [Apache ZooKeeper project page](https://zookeeper.apache.org/).
 
-The charmed operator automates the deployment, scaling, and maintenance of Apache ZooKeeper clusters. It manages leader election, configuration, and synchronisation while handling security features like authentication and access control. The operator enables seamless horizontal scaling, service discovery, and automated recovery, reducing manual intervention. It utilises [Juju](https://juju.is/) for simplified life cycle management across cloud, VM, and bare-metal environments.
+The charm automates the deployment, scaling, and maintenance of Apache ZooKeeper clusters. It manages leader election, configuration, and synchronisation while handling security features like authentication and access control. The operator enables seamless horizontal scaling, service discovery, and automated recovery, reducing manual intervention. It utilises [Juju](https://juju.is/) for simplified life cycle management across cloud, VM, and bare-metal environments.
 
 ```{note}
 This is a [machine](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/machine/) charm. 
-For deploying on Kubernetes, see Apache ZooKeeper K8s charmed operator.
+For deploying on Kubernetes, see [Apache ZooKeeper K8s charm](https://canonical-zookeeper-k8s.readthedocs-hosted.com/).
 ```
-<!-- TODO add a link to the K8s charm above -->
 
 The charm is useful for DevOps teams, platform engineers, and organisations running distributed systems that require reliable coordination. Teams looking to reduce operational overhead, enhance security, and simplify cluster scaling will find it especially useful. 
 
@@ -18,12 +17,12 @@ The charm is useful for DevOps teams, platform engineers, and organisations runn
 
 | | |
 |--|--|
-|  [Tutorial](content/tutorial/index.md) </br>  Get started - a hands-on introduction to Apache ZooKeeper charmed operator for new users </br> |  [How-to guides](content/how-to/index.md) </br> Step-by-step guides covering key operations and common tasks |
+|  [Tutorial](content/tutorial/index.md) </br>  Get started - a hands-on introduction to Apache ZooKeeper charm for new users </br> |  [How-to guides](content/how-to/index.md) </br> Step-by-step guides covering key operations and common tasks |
 |  [Explanation](content/explanation/index.md) </br> Concepts - discussion and clarification of key topics, architecture | [Reference](content/reference/index.md) </br> Technical information and reference materials | 
 
 ## Project and community
 
-Apache ZooKeeper charmed operator is a distribution of Apache ZooKeeper. It’s an open-source project that welcomes community contributions, suggestions, fixes and constructive feedback.
+Apache ZooKeeper charm is a distribution of Apache ZooKeeper. It’s an open-source project that welcomes community contributions, suggestions, fixes and constructive feedback.
 
 - [Read our Code of Conduct](https://ubuntu.com/community/code-of-conduct)
 - [Join the Discourse forum](https://discourse.charmhub.io/tag/kafka)


### PR DESCRIPTION
Charmed operator term is replaced with a shorter one - charm. As recommended by Juju team. Also, that works better for web portal titles - making them shorter and easier to fit into the template.