### PR TITLE
docs: Charmhub terminology fixes

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -2,11 +2,11 @@
 # See LICENSE file for licensing details.
 
 get-super-password:
-  description: Returns the Zookeeper super user password (for the cluster). Used to get
+  description: Returns the Apache Zookeeper super user password (for the cluster). Used to get
     administrator access to the cluster. Used mainly by the Kafka Charmed Operator.
 
 get-sync-password:
-  description: Returns the Zookeeper sync user password. This user is only for internal quorum handling.
+  description: Returns the Apache Zookeeper sync user password. This user is only for internal quorum handling.
 
 pre-upgrade-check:
   description: Run necessary pre-upgrade checks before executing a charm upgrade.

--- a/config.yaml
+++ b/config.yaml
@@ -8,11 +8,11 @@ options:
     type: int
     default: 5
   sync-limit:
-    description: "Amount of time, in ticks, to allow followers to sync with ZooKeeper."
+    description: "Amount of time, in ticks, to allow followers to sync with Apache ZooKeeper."
     type: int
     default: 2
   tick-time:
-    description: "the length of a single tick, which is the basic time unit used by ZooKeeper, as measured in milliseconds."
+    description: "the length of a single tick, which is the basic time unit used by Apache ZooKeeper, as measured in milliseconds."
     type: int
     default: 2000
   log-level:
@@ -20,7 +20,7 @@ options:
     type: string
     default: "INFO"
   expose-external:
-    description: "String to determine how to expose the ZooKeeper cluster externally from the Kubernetes cluster. Possible values: 'nodeport', 'loadbalancer', 'false'"
+    description: "String to determine how to expose the Apache ZooKeeper cluster externally from the Kubernetes cluster. Possible values: 'nodeport', 'loadbalancer', 'false'"
     type: string
     default: "false"
   loadbalancer-extra-annotations:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,11 +3,17 @@
 name: zookeeper
 display-name: Charmed Apache Zookeeper
 description: |
-  ZooKeeper is a centralized service for maintaining configuration information, naming,
+  Charmed Apache Zookeeper is an open-source software operator, 
+  packaged as a [Juju charm](https://documentation.ubuntu.com/juju/3.6/reference/charm/), 
+  that simplifies the deployment, scaling, and management of Apache ZooKeeper clusters.
+
+  [Apache Zookeeper](https://zookeeper.apache.org/) is a free,
+  open-source software project by the Apache Software Foundation.
+
+  Apache ZooKeeper is a centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.
   
-  Apache ZooKeeper is a free, open source software project by the Apache Software Foundation. 
-  Users can find out more at the [ZooKeeper project page](https://zookeeper.apache.org/).
+  See [full Charmed Apache ZooKeeper documentation](https://canonical-zookeeper.readthedocs-hosted.com/).
 summary: Charmed ZooKeeper VM Operator
 source: https://github.com/canonical/zookeeper-operator
 issues: https://github.com/canonical/zookeeper-operator/issues


### PR DESCRIPTION
Update Charmhub description and fix other mentions of ZooKeeper w/o Apache in front.