### PR TITLE
[DPE-10563] chore: add a logging filter to redact sensitive values

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -26,6 +26,7 @@ from ops import (
 )
 
 from core.cluster import ClusterState
+from core.logging import RedactionFilter
 from core.structured_config import CharmConfig
 from events.backup import BackupEvents
 from events.password_actions import PasswordActionEvents
@@ -66,6 +67,9 @@ class ZooKeeperCharm(TypedCharmBase[CharmConfig]):
         self.name = CHARM_KEY
         self.state = ClusterState(self, substrate=SUBSTRATE)
         self.workload = ZKWorkload()
+        redaction_filter = RedactionFilter(self.state)
+        for handler in logger.handlers:
+            handler.addFilter(redaction_filter)
 
         # --- CHARM EVENT HANDLERS ---
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -70,6 +70,7 @@ class ZooKeeperCharm(TypedCharmBase[CharmConfig]):
 
         # --- LOGGING CONFIGURATION ---
 
+        self.logger = logger
         redaction_filter = RedactionFilter(self.state)
         logger.addFilter(redaction_filter)
         for handler in logger.handlers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -67,7 +67,11 @@ class ZooKeeperCharm(TypedCharmBase[CharmConfig]):
         self.name = CHARM_KEY
         self.state = ClusterState(self, substrate=SUBSTRATE)
         self.workload = ZKWorkload()
+
+        # --- LOGGING CONFIGURATION ---
+
         redaction_filter = RedactionFilter(self.state)
+        logger.addFilter(redaction_filter)
         for handler in logger.handlers:
             handler.addFilter(redaction_filter)
 

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -18,7 +18,9 @@ from lightkube.core.exceptions import ApiError as LightKubeApiError
 from ops.framework import Object
 from ops.model import ModelError, Relation, Unit
 from tenacity import retry, retry_if_exception_cause_type, stop_after_attempt, wait_fixed
+from typing_extensions import override
 
+from core.logging import WithSensitiveValues
 from core.models import SUBSTRATES, ZKClient, ZKCluster, ZKServer
 from core.stubs import ExposeExternal
 from literals import (
@@ -36,7 +38,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class ClusterState(Object):
+class ClusterState(Object, WithSensitiveValues):
     """Collection of global cluster state for Framework/Object."""
 
     def __init__(self, charm: "ZooKeeperCharm", substrate: SUBSTRATES):
@@ -326,6 +328,28 @@ class ClusterState(Object):
             return False
 
         return True
+
+    @property
+    @override
+    def sensitive_values(self) -> list[str]:
+        return list(
+            {
+                v
+                for v in [
+                    *[client.password for client in self.clients],
+                    *self.cluster.internal_user_credentials.values(),
+                    *self.cluster.client_passwords.values(),
+                    self.cluster.s3_credentials.get("access-key", ""),
+                    self.cluster.s3_credentials.get("secrety-key", ""),
+                    self.unit_server.private_key,
+                    self.unit_server.keystore_password,
+                    self.unit_server.truststore_password,
+                    self.unit_server.certificate,
+                    self.unit_server.ca,
+                ]
+                if v
+            }
+        )
 
     # --- PASSWORD ROTATION --
 

--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Logging extensions & filters."""
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+
+
+class WithSensitiveValues(ABC):
+    """Interface for an object carrying sensitive values."""
+
+    @property
+    @abstractmethod
+    def sensitive_values(self) -> Iterable[str]:
+        """Return an iterable of sensitive values held by this object."""
+        ...
+
+
+class RedactionFilter(logging.Filter):
+    """Logging filter that redacts a set of secret strings from log messages."""
+
+    REDACTED = "[redacted]"
+
+    def __init__(self, sensitive_object: WithSensitiveValues):
+        self._obj = sensitive_object
+        super().__init__()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Replaces any configured secret found in the record's message with '[redacted]'."""
+        message = record.getMessage()
+        for secret in self._obj.sensitive_values:
+            if secret:
+                message = message.replace(secret, self.REDACTED)
+
+        record.msg = message
+        record.args = ()
+        return True

--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -33,7 +33,7 @@ class RedactionFilter(logging.Filter):
         message = record.getMessage()
         for secret in self._obj.sensitive_values:
             if secret:
-                message = message.replace(secret, self.REDACTED)
+                message = message.replace(str(secret), self.REDACTED)
 
         record.msg = message
         record.args = ()

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -4,7 +4,6 @@
 
 """Event handlers for creating and restoring backups."""
 import json
-import logging
 from typing import TYPE_CHECKING, cast
 
 from charms.data_platform_libs.v0.s3 import (
@@ -25,8 +24,6 @@ from managers.backup import BackupManager
 
 if TYPE_CHECKING:
     from charm import ZooKeeperCharm
-
-logger = logging.getLogger(__name__)
 
 
 class BackupEvents(Object):
@@ -70,7 +67,7 @@ class BackupEvents(Object):
             param for param in required_parameters if param not in s3_parameters
         ]
         if missing_required_parameters:
-            logger.warning(
+            self.charm.logger.warning(
                 f"Missing required S3 parameters in relation with S3 integrator: {missing_required_parameters}"
             )
             self.charm._set_status(Status.MISSING_S3_CONFIG)
@@ -112,7 +109,7 @@ class BackupEvents(Object):
 
         for check, msg in failure_conditions:
             if check:
-                logging.error(msg)
+                self.charm.logger.error(msg)
                 event.set_results({"error": msg})
                 event.fail(msg)
                 return
@@ -135,7 +132,7 @@ class BackupEvents(Object):
 
         for check, msg in failure_conditions:
             if check:
-                logging.error(msg)
+                self.charm.logger.error(msg)
                 event.set_results({"error": msg})
                 event.fail(msg)
                 return
@@ -184,7 +181,7 @@ class BackupEvents(Object):
 
         for check, msg in failure_conditions:
             if check():
-                logging.error(msg)
+                self.charm.logger.error(msg)
                 event.set_results({"error": msg})
                 event.fail(msg)
                 return
@@ -242,19 +239,19 @@ class BackupEvents(Object):
 
     def _stop_workflow(self) -> None:
         self.charm._set_status(Status.ONGOING_RESTORE)
-        logger.info("Restoring - stopping workflow")
+        self.charm.logger.info("Restoring - stopping workflow")
         self.charm.workload.stop()
         self.charm.state.unit_server.update({"restore-progress": RestoreStep.STOP_WORKFLOW.value})
 
     def _download_and_restore(self) -> None:
-        logger.info("Restoring - restore snapshot")
+        self.charm.logger.info("Restoring - restore snapshot")
         self.backup_manager.restore_snapshot(
             self.charm.state.cluster.id_to_restore, self.charm.workload
         )
         self.charm.state.unit_server.update({"restore-progress": RestoreStep.RESTORE.value})
 
     def _restart_workflow(self) -> None:
-        logger.info("Restoring - restarting workflow")
+        self.charm.logger.info("Restoring - restarting workflow")
         self.charm.workload.restart()
         self.charm.state.unit_server.update({"restore-progress": RestoreStep.RESTART.value})
 
@@ -266,6 +263,6 @@ class BackupEvents(Object):
     def _cleaning(self) -> bool | None:
         if not self.charm.workload.healthy:
             return False
-        logger.info("Restoring - cleaning files")
+        self.charm.logger.info("Restoring - cleaning files")
         self.backup_manager.cleanup_leftover_files(self.charm.workload)
         self.charm.state.unit_server.update({"restore-progress": RestoreStep.CLEAN.value})

--- a/src/events/password_actions.py
+++ b/src/events/password_actions.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 """Event handlers for password-related Juju Actions."""
-import logging
 from typing import TYPE_CHECKING
 
 from ops.charm import ActionEvent
@@ -13,8 +12,6 @@ from literals import CHARM_USERS
 
 if TYPE_CHECKING:
     from charm import ZooKeeperCharm
-
-logger = logging.getLogger(__name__)
 
 
 class PasswordActionEvents(Object):
@@ -53,7 +50,7 @@ class PasswordActionEvents(Object):
         """
         if not self.charm.unit.is_leader():
             msg = "Password rotation must be called on leader unit"
-            logger.error(msg)
+            self.charm.logger.error(msg)
             event.fail(msg)
             return
 
@@ -62,14 +59,14 @@ class PasswordActionEvents(Object):
                 "Cannot set password while upgrading "
                 + f"(upgrade_stack: {self.charm.upgrade_events.upgrade_stack})"
             )
-            logger.error(msg)
+            self.charm.logger.error(msg)
             event.fail(msg)
             return
 
         username = event.params.get("username", "super")
         if username not in CHARM_USERS:
             msg = f"The action can be run only for users used by the charm: {CHARM_USERS} not {username}."
-            logger.error(msg)
+            self.charm.logger.error(msg)
             event.fail(msg)
             return
 

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 """Event handler for related applications on the `zookeeper` relation interface."""
-import logging
 from typing import TYPE_CHECKING
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseProviderEventHandlers
@@ -20,8 +19,6 @@ from literals import REL_NAME
 
 if TYPE_CHECKING:
     from charm import ZooKeeperCharm
-
-logger = logging.getLogger(__name__)
 
 
 class ProviderEvents(Object):
@@ -73,7 +70,7 @@ class ProviderEvents(Object):
             QuorumLeaderNotFoundError,
             KazooTimeoutError,
         ) as e:
-            logger.warning(str(e))
+            self.charm.logger.warning(str(e))
             event.defer()
             return
 

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -5,7 +5,6 @@
 """Event handler for related applications on the `certificates` relation interface."""
 import base64
 import json
-import logging
 import re
 from typing import TYPE_CHECKING
 
@@ -22,8 +21,6 @@ from literals import Status
 
 if TYPE_CHECKING:
     from charm import ZooKeeperCharm
-
-logger = logging.getLogger(__name__)
 
 
 class TLSEvents(Object):
@@ -60,7 +57,9 @@ class TLSEvents(Object):
             return
 
         if not self.charm.state.stable == Status.ACTIVE:
-            logger.debug("certificates relation created - quorum not stable - deferring")
+            self.charm.logger.debug(
+                "certificates relation created - quorum not stable - deferring"
+            )
             event.defer()
             return
 
@@ -72,7 +71,7 @@ class TLSEvents(Object):
     def _on_certificates_joined(self, event: RelationJoinedEvent) -> None:
         """Handler for `certificates_relation_joined` event."""
         if not self.charm.state.cluster.tls:
-            logger.debug(
+            self.charm.logger.debug(
                 "certificates relation joined - tls not enabled and not switching encryption - deferring"
             )
             event.defer()
@@ -112,7 +111,7 @@ class TLSEvents(Object):
         """Handler for `certificates_available` event after provider updates signed certs."""
         # avoid setting tls files and restarting
         if event.certificate_signing_request != self.charm.state.unit_server.csr:
-            logger.error("Can't use certificate, found unknown CSR")
+            self.charm.logger.error("Can't use certificate, found unknown CSR")
             return
 
         self.charm.state.unit_server.update(
@@ -136,7 +135,7 @@ class TLSEvents(Object):
     def _on_certificate_expiring(self, _: EventBase) -> None:
         """Handler for `certificates_expiring` event when certs need renewing."""
         if not (self.charm.state.unit_server.private_key or self.charm.state.unit_server.csr):
-            logger.error("Missing unit private key and/or old csr")
+            self.charm.logger.error("Missing unit private key and/or old csr")
             return
 
         subject = self.charm.state.unit_server.internal_address

--- a/src/events/upgrade.py
+++ b/src/events/upgrade.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 """Event handler for handling ZooKeeper in-place upgrades."""
-import logging
 import time
 from functools import cached_property
 from typing import TYPE_CHECKING
@@ -23,8 +22,6 @@ from literals import CLIENT_PORT
 
 if TYPE_CHECKING:
     from charm import ZooKeeperCharm
-
-logger = logging.getLogger(__name__)
 
 
 class ZooKeeperDependencyModel(BaseModel):
@@ -87,7 +84,7 @@ class ZKUpgradeEvents(DataUpgrade):
 
     @override
     def log_rollback_instructions(self) -> None:
-        logger.critical(
+        self.charm.logger.critical(
             "\n".join(
                 [
                     "Unit failed to upgrade and requires manual rollback to previous stable version.",
@@ -103,31 +100,31 @@ class ZKUpgradeEvents(DataUpgrade):
         self.charm.workload.stop()
 
         if not self.charm.workload.install():
-            logger.error("Unable to install ZooKeeper...")
+            self.charm.logger.error("Unable to install ZooKeeper...")
             self.set_unit_failed()
             return
 
         self.apply_backwards_compatibility_fixes()
 
-        logger.info(f"{self.charm.unit.name} upgrading workload...")
+        self.charm.logger.info(f"{self.charm.unit.name} upgrading workload...")
         self.charm.workload.restart()
 
         time.sleep(5.0)
 
         try:
-            logger.debug("Running post-upgrade check...")
+            self.charm.logger.debug("Running post-upgrade check...")
             self.post_upgrade_check()
 
-            logger.debug("Marking unit completed...")
+            self.charm.logger.debug("Marking unit completed...")
             self.set_unit_completed()
 
             # ensures leader gets it's own relation-changed when it upgrades
             if self.charm.unit.is_leader():
-                logger.debug("Re-emitting upgrade-changed on leader...")
+                self.charm.logger.debug("Re-emitting upgrade-changed on leader...")
                 self.on_upgrade_changed(event)
 
         except ClusterNotReadyError as e:
-            logger.error(e.cause)
+            self.charm.logger.error(e.cause)
             self.set_unit_failed()
 
     def apply_backwards_compatibility_fixes(self) -> None:

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -22,6 +22,7 @@ from rich.console import Console
 from rich.table import Table
 
 from core.cluster import ClusterState
+from core.logging import RedactionFilter
 from core.stubs import BackupMetadata, S3ConnectionInfo
 from literals import ADMIN_SERVER_PORT, PATHS, S3_BACKUPS_LIMIT, S3_BACKUPS_PATH, USER
 from workload import ZKWorkload
@@ -35,6 +36,9 @@ class BackupManager:
     def __init__(self, state: ClusterState) -> None:
         self.state = state
         self.backups_path = S3_BACKUPS_PATH
+        redaction_filter = RedactionFilter(self.state)
+        for handler in logger.handlers:
+            handler.addFilter(redaction_filter)
 
     @property
     def bucket(self) -> Bucket:

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -36,7 +36,9 @@ class BackupManager:
     def __init__(self, state: ClusterState) -> None:
         self.state = state
         self.backups_path = S3_BACKUPS_PATH
+
         redaction_filter = RedactionFilter(self.state)
+        logger.addFilter(redaction_filter)
         for handler in logger.handlers:
             handler.addFilter(redaction_filter)
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -63,7 +63,9 @@ class ConfigManager:
         self.workload = workload
         self.substrate = substrate
         self.config = config
+
         redaction_filter = RedactionFilter(self.state)
+        logger.addFilter(redaction_filter)
         for handler in logger.handlers:
             handler.addFilter(redaction_filter)
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -7,6 +7,7 @@ import logging
 from textwrap import dedent
 
 from core.cluster import SUBSTRATES, ClusterState
+from core.logging import RedactionFilter
 from core.structured_config import CharmConfig
 from core.workload import WorkloadBase
 from literals import JMX_PORT, METRICS_PROVIDER_PORT
@@ -62,6 +63,9 @@ class ConfigManager:
         self.workload = workload
         self.substrate = substrate
         self.config = config
+        redaction_filter = RedactionFilter(self.state)
+        for handler in logger.handlers:
+            handler.addFilter(redaction_filter)
 
     @property
     def log_level(self) -> str:

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -34,7 +34,9 @@ class QuorumManager:
 
     def __init__(self, state: ClusterState):
         self.state = state
+
         redaction_filter = RedactionFilter(self.state)
+        logger.addFilter(redaction_filter)
         for handler in logger.handlers:
             handler.addFilter(redaction_filter)
 

--- a/src/managers/quorum.py
+++ b/src/managers/quorum.py
@@ -22,6 +22,7 @@ from kazoo.security import make_acl, make_digest_acl_credential
 from ops.charm import RelationEvent
 
 from core.cluster import ClusterState
+from core.logging import RedactionFilter
 from core.models import ZKServer
 from literals import CLIENT_PORT
 
@@ -33,6 +34,9 @@ class QuorumManager:
 
     def __init__(self, state: ClusterState):
         self.state = state
+        redaction_filter = RedactionFilter(self.state)
+        for handler in logger.handlers:
+            handler.addFilter(redaction_filter)
 
     @cached_property
     def client(self) -> ZooKeeperManager:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -37,7 +37,9 @@ class TLSManager:
         self.workload = workload
         self.substrate = substrate
         self.config = config
+
         redaction_filter = RedactionFilter(self.state)
+        logger.addFilter(redaction_filter)
         for handler in logger.handlers:
             handler.addFilter(redaction_filter)
 

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -14,6 +14,7 @@ from lightkube.core.exceptions import ApiError as LightKubeApiError
 from tenacity import retry, retry_if_exception_cause_type, stop_after_attempt, wait_fixed
 
 from core.cluster import SUBSTRATES, ClusterState
+from core.logging import RedactionFilter
 from core.structured_config import CharmConfig
 from core.stubs import SANs
 from core.workload import WorkloadBase
@@ -36,6 +37,9 @@ class TLSManager:
         self.workload = workload
         self.substrate = substrate
         self.config = config
+        redaction_filter = RedactionFilter(self.state)
+        for handler in logger.handlers:
+            handler.addFilter(redaction_filter)
 
     @retry(
         wait=wait_fixed(5),


### PR DESCRIPTION
## Description

Adds a RedactionFilter to loggers, which may log sensitive content.

This PR is backed by an analysis of source code done using Claude Code.

## Logging Analysis

### Dynamic log messages in `src`

Log call sites whose message text varies at runtime. 36 of the 65 `logger` calls in `src`.

#### Group A — f-string interpolation (21)

Literal string with variables interpolated into it. Stable prefix, so greppable.

| Location | Interpolated value(s) |
|---|---|
| `src/charm.py:305` | `{self.unit.name} restarting...` |
| `src/charm.py:348` | `{self.unit.name} initializing...` |
| `src/charm.py:382` | `{self.unit.name} started` |
| `src/charm.py:412` | `{updated_servers=}` |
| `src/charm.py:440` | `...switching to {self.state.cluster.quorum} quorum` |
| `src/charm.py:470` | `Skipping update of {client.component.name}...` |
| `src/core/cluster.py:440` | `Can't retrieve network binding data: {e}` |
| `src/core/models.py:59` | `Fields {list(items.keys())} were attempted...` |
| `src/managers/backup.py:95` | `Using existing bucket {bucket_name}` |
| `src/managers/backup.py:100` | `Created bucket {bucket_name}` |
| `src/managers/config.py:405` | server/config property set-diffs (two sets) |
| `src/managers/config.py:415` | JAAS set-diffs (two sets) |
| `src/managers/config.py:426` | `{self.log_level}` |
| `src/managers/quorum.py:192` | `{leader_chroots=}` |
| `src/managers/quorum.py:213` | `{sasl_acl=}` |
| `src/managers/quorum.py:224` | `CREATE CHROOT - {client.database}` |
| `src/managers/quorum.py:228` | `UPDATE CHROOT - {client.database}` |
| `src/events/backup.py:73` | `{missing_required_parameters}` |
| `src/events/upgrade.py:112` | `{self.charm.unit.name} upgrading workload...` |
| `src/events/password_actions.py:65` | `{...upgrade_stack}` (msg built at :61-64) |
| `src/events/password_actions.py:72` | `{CHARM_USERS}`, `{username}` (msg built at :71) |

#### Group B — bare variable, no literal text (15)

The whole message is an exception or attribute. No static text to grep for.

| Location | Message |
|---|---|
| `src/managers/tls.py:89` | `e.stdout` |
| `src/managers/tls.py:173` | `str(e.stdout)` |
| `src/managers/tls.py:190` | `str(e.stdout)` |
| `src/managers/tls.py:273` | `str(e.stdout)` |
| `src/managers/tls.py:284` | `str(e.stdout)` |
| `src/workload.py:38` | `str(e)` (`.exception`) |
| `src/workload.py:45` | `str(e)` (`.exception`) |
| `src/workload.py:52` | `str(e)` (`.exception`) |
| `src/workload.py:142` | `str(e)` |
| `src/managers/quorum.py:85` | `str(e)` |
| `src/managers/quorum.py:154` | `str(e)` |
| `src/events/provider.py:76` | `str(e)` |
| `src/events/upgrade.py:130` | `e.cause` |
| `src/managers/k8s.py:46` | `e.status.message` |
| `src/core/cluster.py:468` | `e` (object passed directly, not stringified) |
